### PR TITLE
feat(ui): add table view as alternative to schema tree on detail pages

### DIFF
--- a/src/components/SchemaTable.tsx
+++ b/src/components/SchemaTable.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+
+interface Property {
+  description?: string;
+  type?: string | string[];
+  $ref?: string;
+  format?: string;
+  items?: any;
+  properties?: Record<string, Property>;
+  required?: string[] | boolean;
+  default?: any;
+}
+
+interface Schema {
+  title?: string;
+  description?: string;
+  properties?: Record<string, Property>;
+  required?: string[];
+}
+
+interface TableRow {
+  path: string;
+  depth: number;
+  type: string;
+  required: boolean;
+  default?: any;
+  description?: string;
+}
+
+interface Props {
+  initialSchema: Schema;
+}
+
+function getType(prop: Property): string {
+  if (prop.type) {
+    if (Array.isArray(prop.type)) return prop.type.join(' | ');
+    return prop.type;
+  }
+  if (prop.$ref) {
+    return prop.$ref.split('/').pop() || 'object';
+  }
+  return 'string';
+}
+
+function flattenSchema(
+  properties: Record<string, Property>,
+  required: string[] | undefined,
+  prefix: string,
+  depth: number,
+  rows: TableRow[]
+): void {
+  for (const [name, prop] of Object.entries(properties)) {
+    const path = prefix ? `${prefix}.${name}` : name;
+    const isRequired = Array.isArray(required) ? required.includes(name) : false;
+
+    // Determine display type; arrays of objects get [] suffix
+    let type = getType(prop);
+    if (prop.type === 'array' && prop.items) {
+      const itemType = prop.items.type || (prop.items.$ref ? prop.items.$ref.split('/').pop() : 'object');
+      type = `${itemType}[]`;
+    }
+
+    rows.push({
+      path,
+      depth,
+      type,
+      required: isRequired,
+      default: prop.default,
+      description: prop.description,
+    });
+
+    // Recurse into inline object properties
+    if (prop.properties && Object.keys(prop.properties).length > 0) {
+      flattenSchema(
+        prop.properties,
+        Array.isArray(prop.required) ? prop.required : undefined,
+        path,
+        depth + 1,
+        rows
+      );
+    }
+
+    // Recurse into array items that have properties
+    if (prop.type === 'array' && prop.items?.properties) {
+      const itemsRequired = Array.isArray(prop.items.required) ? prop.items.required : undefined;
+      flattenSchema(prop.items.properties, itemsRequired, `${path}[]`, depth + 1, rows);
+    }
+  }
+}
+
+export default function SchemaTable({ initialSchema }: Props) {
+  if (!initialSchema.properties) {
+    return <div className="p-8 text-center text-gray-500 italic">No properties defined.</div>;
+  }
+
+  const rows: TableRow[] = [];
+  flattenSchema(initialSchema.properties, initialSchema.required, '', 0, rows);
+
+  return (
+    <div className="border border-gray-200 dark:border-slate-700 rounded-xl overflow-hidden shadow-sm bg-white dark:bg-slate-900">
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="bg-gray-50 dark:bg-slate-800 border-b border-gray-200 dark:border-slate-700">
+              <th className="text-left px-4 py-3 font-black text-gray-400 dark:text-slate-500 uppercase tracking-[0.15em] w-2/5">Field</th>
+              <th className="text-left px-4 py-3 font-black text-gray-400 dark:text-slate-500 uppercase tracking-[0.15em] w-24">Type</th>
+              <th className="text-left px-4 py-3 font-black text-gray-400 dark:text-slate-500 uppercase tracking-[0.15em] w-20">Required</th>
+              <th className="text-left px-4 py-3 font-black text-gray-400 dark:text-slate-500 uppercase tracking-[0.15em] w-24">Default</th>
+              <th className="text-left px-4 py-3 font-black text-gray-400 dark:text-slate-500 uppercase tracking-[0.15em]">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr
+                key={row.path}
+                className={`border-b border-gray-100 dark:border-slate-800 hover:bg-blue-50/40 dark:hover:bg-slate-800/60 transition-colors ${
+                  row.required ? 'bg-red-50/20 dark:bg-red-900/10' : ''
+                } ${i === rows.length - 1 ? 'border-b-0' : ''}`}
+              >
+                <td className="px-4 py-3 font-mono">
+                  <span style={{ paddingLeft: `${row.depth * 16}px` }} className="inline-block">
+                    <code className={`px-1.5 py-0.5 rounded text-xs ${
+                      row.required
+                        ? 'text-blue-700 dark:text-blue-300 font-bold bg-blue-50 dark:bg-blue-900/30'
+                        : 'text-blue-600 dark:text-blue-400 bg-blue-50/70 dark:bg-blue-900/20'
+                    }`}>
+                      {row.path}
+                    </code>
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="text-[10px] font-medium text-gray-500 dark:text-slate-400 bg-gray-100 dark:bg-slate-700 px-1.5 py-0.5 rounded border border-gray-200 dark:border-slate-600 whitespace-nowrap">
+                    {row.type}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  {row.required && (
+                    <span className="text-[9px] font-bold text-red-500 dark:text-red-400 uppercase tracking-tighter">
+                      Required
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  {row.default !== undefined && (
+                    <code className="text-[10px] text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 px-1.5 py-0.5 rounded">
+                      {JSON.stringify(row.default)}
+                    </code>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-gray-500 dark:text-slate-400 leading-relaxed">
+                  {row.description && (
+                    <span
+                      className="block max-w-prose truncate"
+                      title={row.description}
+                    >
+                      {row.description}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="px-4 py-2 bg-gray-50 dark:bg-slate-800 border-t border-gray-100 dark:border-slate-700 text-[10px] text-gray-400 dark:text-slate-500 font-bold">
+        {rows.length} field{rows.length !== 1 ? 's' : ''}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SchemaViewToggle.tsx
+++ b/src/components/SchemaViewToggle.tsx
@@ -1,0 +1,146 @@
+import React, { useState, useEffect } from 'react';
+import SchemaTree from './SchemaTree';
+import SchemaTable from './SchemaTable';
+
+type ViewMode = 'tree' | 'table';
+const STORAGE_KEY = 'openspec-schema-view';
+
+interface Schema {
+  title?: string;
+  description?: string;
+  properties?: Record<string, any>;
+  required?: string[];
+}
+
+interface Props {
+  initialSchema: Schema;
+  titles: Record<string, string>;
+  schemaJson?: string;
+  schemaFile?: string;
+}
+
+type CopyState = 'idle' | 'copied' | 'failed';
+
+export default function SchemaViewToggle({ initialSchema, titles, schemaJson = '', schemaFile = '' }: Props) {
+  const [view, setView] = useState<ViewMode>('tree');
+  const [yamlCopy, setYamlCopy] = useState<CopyState>('idle');
+  const [jsonCopy, setJsonCopy] = useState<CopyState>('idle');
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY) as ViewMode | null;
+      if (saved === 'tree' || saved === 'table') {
+        setView(saved);
+      }
+    } catch {
+      // localStorage unavailable (e.g. private browsing restrictions)
+    }
+  }, []);
+
+  const switchView = (next: ViewMode) => {
+    setView(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // ignore write failures
+    }
+  };
+
+  const copyYamlDirective = async () => {
+    const directive = `# yaml-language-server: $schema=https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/${schemaFile}`;
+    try {
+      await navigator.clipboard.writeText(directive);
+      setYamlCopy('copied');
+    } catch {
+      setYamlCopy('failed');
+    }
+    setTimeout(() => setYamlCopy('idle'), 2000);
+  };
+
+  const copyJson = async () => {
+    try {
+      await navigator.clipboard.writeText(schemaJson);
+      setJsonCopy('copied');
+    } catch {
+      setJsonCopy('failed');
+    }
+    setTimeout(() => setJsonCopy('idle'), 2000);
+  };
+
+  const btnBase =
+    'flex items-center gap-1.5 text-[10px] px-3 py-1.5 rounded-full font-bold border transition-colors';
+  const activeBtn =
+    'bg-blue-600 text-white border-blue-600 dark:bg-blue-500 dark:border-blue-500';
+  const inactiveBtn =
+    'bg-white dark:bg-slate-900 text-gray-500 dark:text-slate-400 border-gray-200 dark:border-slate-700 hover:border-blue-300 dark:hover:border-blue-600 hover:text-blue-600 dark:hover:text-blue-400';
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-xs font-black text-gray-400 dark:text-slate-500 uppercase tracking-[0.2em]">
+          Resource Structure
+        </h2>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={copyYamlDirective}
+            className={`text-[10px] bg-white dark:bg-slate-900 px-3 py-1.5 rounded-full font-bold border transition-colors flex items-center gap-1.5 ${
+              yamlCopy === 'copied'
+                ? 'border-purple-300 text-purple-600 dark:border-purple-600 dark:text-purple-400'
+                : 'text-gray-500 dark:text-slate-400 border-gray-200 dark:border-slate-700 hover:border-purple-300 dark:hover:border-purple-600 hover:text-purple-600 dark:hover:text-purple-400'
+            }`}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>
+            </svg>
+            {yamlCopy === 'copied' ? 'Copied!' : yamlCopy === 'failed' ? 'Failed' : 'Copy YAML directive'}
+          </button>
+          <button
+            onClick={copyJson}
+            className={`text-[10px] bg-white dark:bg-slate-900 px-3 py-1.5 rounded-full font-bold border transition-colors flex items-center gap-1.5 ${
+              jsonCopy === 'copied'
+                ? 'border-green-300 text-green-600 dark:border-green-600 dark:text-green-400'
+                : 'text-gray-500 dark:text-slate-400 border-gray-200 dark:border-slate-700 hover:border-blue-300 dark:hover:border-blue-600 hover:text-blue-600 dark:hover:text-blue-400'
+            }`}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
+            </svg>
+            {jsonCopy === 'copied' ? 'Copied!' : jsonCopy === 'failed' ? 'Failed' : 'Copy JSON'}
+          </button>
+
+          {/* View toggle */}
+          <div className="flex items-center gap-1 bg-gray-100 dark:bg-slate-800 rounded-full p-0.5 border border-gray-200 dark:border-slate-700">
+            <button
+              onClick={() => switchView('tree')}
+              className={`${btnBase} ${view === 'tree' ? activeBtn : inactiveBtn}`}
+              aria-pressed={view === 'tree'}
+              title="Tree view"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14"/><path d="M21 19v-4H9a2 2 0 0 0 0 4h12v-4"/>
+              </svg>
+              Tree
+            </button>
+            <button
+              onClick={() => switchView('table')}
+              className={`${btnBase} ${view === 'table' ? activeBtn : inactiveBtn}`}
+              aria-pressed={view === 'table'}
+              title="Table view"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <rect width="18" height="18" x="3" y="3" rx="2"/><path d="M3 9h18M3 15h18M9 3v18"/>
+              </svg>
+              Table
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {view === 'tree' ? (
+        <SchemaTree initialSchema={initialSchema} titles={titles} />
+      ) : (
+        <SchemaTable initialSchema={initialSchema} />
+      )}
+    </div>
+  );
+}

--- a/src/pages/schemas/[...slug].astro
+++ b/src/pages/schemas/[...slug].astro
@@ -2,7 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import catalog from '../../../public/data/catalog.json';
 import titles from '../../../public/data/titles.json';
-import SchemaTree from '../../components/SchemaTree';
+import SchemaViewToggle from '../../components/SchemaViewToggle';
 import SchemaDiffViewer from '../../components/SchemaDiffViewer';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -66,34 +66,13 @@ const schemaDescription = schema.description || `Kubernetes CRD schema for ${kin
 		</header>
 
 		<section>
-			<div class="flex justify-between items-center mb-6">
-				<h2 class="text-xs font-black text-gray-400 dark:text-slate-500 uppercase tracking-[0.2em]">Resource Structure</h2>
-				<div class="flex items-center gap-2">
-					<button
-						id="copy-yaml-directive"
-						class="text-[10px] bg-white dark:bg-slate-900 text-gray-500 dark:text-slate-400 px-3 py-1.5 rounded-full font-bold border border-gray-200 dark:border-slate-700 hover:border-purple-300 dark:hover:border-purple-600 hover:text-purple-600 dark:hover:text-purple-400 transition-colors flex items-center gap-1.5"
-					>
-						<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-							<polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/>
-						</svg>
-						<span id="yaml-directive-label">Copy YAML directive</span>
-					</button>
-					<button
-						id="copy-schema"
-						class="text-[10px] bg-white dark:bg-slate-900 text-gray-500 dark:text-slate-400 px-3 py-1.5 rounded-full font-bold border border-gray-200 dark:border-slate-700 hover:border-blue-300 dark:hover:border-blue-600 hover:text-blue-600 dark:hover:text-blue-400 transition-colors flex items-center gap-1.5"
-					>
-						<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-							<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
-						</svg>
-						<span id="copy-label">Copy JSON</span>
-					</button>
-					<span class="text-[10px] bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 px-2 py-1 rounded-full font-bold border border-blue-100 dark:border-blue-800">
-						Interactive Tree
-					</span>
-				</div>
-			</div>
-
-			<SchemaTree client:load initialSchema={schema} titles={titles as any} />
+			<SchemaViewToggle
+				client:load
+				initialSchema={schema}
+				titles={titles as any}
+				schemaJson={JSON.stringify(schema, null, 2)}
+				schemaFile={file}
+			/>
 		</section>
 
 		{siblingVersions.length > 1 && (
@@ -114,46 +93,3 @@ const schemaDescription = schema.description || `Kubernetes CRD schema for ${kin
 		</footer>
 	</div>
 </Layout>
-
-<script define:vars={{ schemaJson: JSON.stringify(schema, null, 2), schemaFile: file }}>
-	const yamlBtn = document.getElementById('copy-yaml-directive');
-	const yamlLabel = document.getElementById('yaml-directive-label');
-	const yamlDirective = `# yaml-language-server: $schema=https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/${schemaFile}`;
-
-	yamlBtn?.addEventListener('click', async () => {
-		try {
-			await navigator.clipboard.writeText(yamlDirective);
-			if (yamlLabel) yamlLabel.textContent = 'Copied!';
-			yamlBtn.classList.add('border-purple-300', 'text-purple-600');
-			yamlBtn.classList.remove('border-gray-200', 'text-gray-500');
-			setTimeout(() => {
-				if (yamlLabel) yamlLabel.textContent = 'Copy YAML directive';
-				yamlBtn.classList.remove('border-purple-300', 'text-purple-600');
-				yamlBtn.classList.add('border-gray-200', 'text-gray-500');
-			}, 2000);
-		} catch {
-			if (yamlLabel) yamlLabel.textContent = 'Failed';
-			setTimeout(() => { if (yamlLabel) yamlLabel.textContent = 'Copy YAML directive'; }, 2000);
-		}
-	});
-
-	const btn = document.getElementById('copy-schema');
-	const label = document.getElementById('copy-label');
-
-	btn?.addEventListener('click', async () => {
-		try {
-			await navigator.clipboard.writeText(schemaJson);
-			if (label) label.textContent = 'Copied!';
-			btn.classList.add('border-green-300', 'text-green-600');
-			btn.classList.remove('border-gray-200', 'text-gray-500');
-			setTimeout(() => {
-				if (label) label.textContent = 'Copy JSON';
-				btn.classList.remove('border-green-300', 'text-green-600');
-				btn.classList.add('border-gray-200', 'text-gray-500');
-			}, 2000);
-		} catch {
-			if (label) label.textContent = 'Failed';
-			setTimeout(() => { if (label) label.textContent = 'Copy JSON'; }, 2000);
-		}
-	});
-</script>


### PR DESCRIPTION
## Summary

- Add `SchemaTable` component that renders JSON schemas as a flat table with dot-notation field paths, depth indentation, type badges, required highlighting, default values, and full description via tooltip
- Add `SchemaViewToggle` wrapper that manages tree/table toggle with preference persisted in `localStorage`; also owns copy-YAML-directive and copy-JSON buttons (moved from Astro script block to avoid hydration race conditions)
- Update `[...slug].astro` detail page to use `SchemaViewToggle` instead of `SchemaTree` directly

Closes: #230