### PR TITLE
feat(schemas): add advanced filtering and group-level listing pages

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -76,11 +76,11 @@ const currentPath = Astro.url.pathname;
 			</div>
 			<nav class="flex-1 overflow-y-auto p-4 space-y-1 scrollbar-thin">
 				{groups.map(([group, resources]) => {
-					const isActiveGroup = resources.some(r => currentPath === `/schemas/${r.slug}`);
+					const isActiveGroup = currentPath === `/schemas/${group}` || resources.some(r => currentPath === `/schemas/${r.slug}`);
 					return (
 						<details class="api-group" data-group={group} open={isActiveGroup || undefined}>
 							<summary class="text-[10px] font-bold text-gray-400 dark:text-slate-500 uppercase tracking-widest border-b border-gray-100 dark:border-slate-800 pb-1 pt-3 cursor-pointer list-none flex justify-between items-center hover:text-blue-500 dark:hover:text-blue-400 transition-colors select-none">
-								<span class="truncate">{group}</span>
+								<a href={`/schemas/${group}`} class="truncate hover:text-blue-600 dark:hover:text-blue-400" onclick="event.stopPropagation()">{group}</a>
 								<span class="flex items-center gap-1 shrink-0 ml-1">
 									<span class="text-[9px] px-1.5 bg-gray-100 dark:bg-slate-800 text-gray-400 dark:text-slate-500 rounded font-normal normal-case tracking-normal">{resources.length}</span>
 									<span class="text-gray-300 dark:text-slate-600 text-[8px]">▾</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -174,6 +174,18 @@ if (otherGroups.length > 0) {
 const allResources = groups.flatMap(([group, resources]) =>
   resources.map((res) => ({ kind: res.kind, group, version: res.version, slug: res.slug }))
 );
+
+// Serializable filter data for client-side filtering (no functions/icons)
+const filterData = groupedData.map(cat => ({
+  name: cat.name,
+  count: cat.count,
+  versionCounts: cat.groups
+    .flatMap(([_, res]) => res as { version: string }[])
+    .reduce((acc: Record<string, number>, r) => {
+      acc[r.version] = (acc[r.version] ?? 0) + 1;
+      return acc;
+    }, {}),
+}));
 ---
 
 <Layout title="Home">
@@ -273,12 +285,33 @@ const allResources = groups.flatMap(([group, resources]) =>
     </div>
   </div>
 
+  <!-- Filter bar -->
+  <div class="max-w-6xl mx-auto px-6 py-4 border-b border-gray-100 dark:border-slate-800">
+    <div class="flex flex-wrap items-center gap-3">
+      <select
+        id="filter-category"
+        class="text-xs border border-gray-200 dark:border-slate-700 rounded-xl px-3 py-2 bg-white dark:bg-slate-900 text-gray-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-400 cursor-pointer min-w-[170px]"
+      >
+        <option value="">All Categories</option>
+      </select>
+      <select
+        id="filter-version"
+        class="text-xs border border-gray-200 dark:border-slate-700 rounded-xl px-3 py-2 bg-white dark:bg-slate-900 text-gray-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-400 cursor-pointer min-w-[120px]"
+      >
+        <option value="">All Versions</option>
+      </select>
+      <span id="filter-count" class="text-xs text-gray-400 dark:text-slate-500 ml-1"></span>
+    </div>
+    <div id="filter-chips" class="flex flex-wrap gap-2 mt-2 empty:hidden"></div>
+  </div>
+
   <!-- Category grid -->
   <div class="max-w-6xl mx-auto px-6 pb-16">
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div id="category-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
       {
-        groupedData.map((cat) => (
+        groupedData.map((cat, idx) => (
           <div
+            data-cat-idx={idx}
             class={`p-8 border rounded-3xl transition-all hover:shadow-xl group hover:-translate-y-1 bg-white dark:bg-slate-900 ${cat.border} ${cat.topBorder}`}
           >
             <div class="flex items-start justify-between mb-6">
@@ -289,7 +322,7 @@ const allResources = groups.flatMap(([group, resources]) =>
               </div>
               <div class="text-right">
                 <div class="text-[10px] font-black uppercase tracking-[0.2em] text-gray-400 dark:text-slate-500 mb-1">Resources</div>
-                <div class="text-2xl font-black text-gray-900 dark:text-white">{cat.count}</div>
+                <div class="text-2xl font-black text-gray-900 dark:text-white" data-count>{cat.count}</div>
               </div>
             </div>
 
@@ -320,10 +353,16 @@ const allResources = groups.flatMap(([group, resources]) =>
         ))
       }
     </div>
+    <div id="filter-empty-state" class="hidden py-16 text-center">
+      <p class="text-gray-400 dark:text-slate-500 text-sm">No categories match the selected filters.</p>
+      <button id="filter-clear-all" class="mt-4 text-xs text-blue-600 dark:text-blue-400 hover:underline">
+        Clear all filters
+      </button>
+    </div>
   </div>
 </Layout>
 
-<script define:vars={{ allResources }}>
+<script define:vars={{ allResources, filterData }}>
   const input = /** @type {HTMLInputElement} */ (document.getElementById('hero-search'));
   const resultsList = document.getElementById('hero-results');
   const hints = document.getElementById('search-hints');
@@ -418,4 +457,172 @@ const allResources = groups.flatMap(([group, resources]) =>
       if (hints) hints.classList.add('hidden');
     }
   });
+
+  // ── Advanced Filters ──────────────────────────────────────────────────────
+
+  let activeCategoryIdx = -1;
+  let activeVersion = '';
+
+  function slugify(name) {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  }
+
+  // Matches only K8s semantic maturity versions (v1, v1beta1, v2alpha1, etc.)
+  // Excludes Azure-style date versions like v1api20240101
+  const K8S_VERSION_RE = /^v\d+(alpha\d+|beta\d+)?$/;
+
+  function versionSortKey(v) {
+    const m = v.match(/^v(\d+)(alpha(\d+)|beta(\d+))?$/);
+    if (!m) return [999, 0, 0];
+    const major = parseInt(m[1]);
+    if (!m[2]) return [major, 3, 0];         // stable: highest priority
+    if (m[4] != null) return [major, 2, parseInt(m[4])];  // beta
+    return [major, 1, parseInt(m[3])];        // alpha
+  }
+
+  function populateDropdowns() {
+    const catSel = /** @type {HTMLSelectElement} */ (document.getElementById('filter-category'));
+    const verSel = /** @type {HTMLSelectElement} */ (document.getElementById('filter-version'));
+    if (!catSel || !verSel) return;
+
+    filterData.forEach((cat, idx) => {
+      const opt = document.createElement('option');
+      opt.value = String(idx);
+      opt.textContent = `${cat.name} (${cat.count})`;
+      catSel.appendChild(opt);
+    });
+
+    const versionSet = new Set();
+    filterData.forEach(cat => Object.keys(cat.versionCounts).forEach(v => {
+      if (K8S_VERSION_RE.test(v)) versionSet.add(v);
+    }));
+    [...versionSet].sort((a, b) => {
+      const ka = versionSortKey(a), kb = versionSortKey(b);
+      for (let i = 0; i < 3; i++) if (ka[i] !== kb[i]) return kb[i] - ka[i];
+      return 0;
+    }).forEach(v => {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = v;
+      verSel.appendChild(opt);
+    });
+  }
+
+  function applyFilters() {
+    const cards = /** @type {NodeListOf<HTMLElement>} */ (document.querySelectorAll('[data-cat-idx]'));
+    let totalVisible = 0, visibleCardCount = 0;
+
+    cards.forEach(card => {
+      const idx = parseInt(card.dataset.catIdx ?? '0');
+      const cat = filterData[idx];
+      const categoryPass = activeCategoryIdx === -1 || idx === activeCategoryIdx;
+      const versionCount = activeVersion ? (cat.versionCounts[activeVersion] ?? 0) : cat.count;
+      const versionPass = !activeVersion || versionCount > 0;
+      const visible = categoryPass && versionPass;
+      card.style.display = visible ? '' : 'none';
+
+      if (visible) {
+        visibleCardCount++;
+        totalVisible += activeVersion ? versionCount : cat.count;
+        const countEl = card.querySelector('[data-count]');
+        if (countEl) countEl.textContent = activeVersion ? String(versionCount) : String(cat.count);
+      }
+    });
+
+    document.getElementById('filter-empty-state')?.classList.toggle('hidden', visibleCardCount > 0);
+    updateResultsCount(totalVisible);
+    renderChips();
+  }
+
+  function updateResultsCount(total) {
+    const el = document.getElementById('filter-count');
+    if (!el) return;
+    if (activeCategoryIdx === -1 && !activeVersion) { el.textContent = ''; return; }
+    const parts = [`Showing ${total.toLocaleString()} schema${total !== 1 ? 's' : ''}`];
+    if (activeCategoryIdx !== -1) parts.push(filterData[activeCategoryIdx].name);
+    if (activeVersion) parts.push(activeVersion);
+    el.textContent = parts.join(' × ');
+  }
+
+  function renderChips() {
+    const container = document.getElementById('filter-chips');
+    if (!container) return;
+    while (container.firstChild) container.removeChild(container.firstChild);
+
+    function makeChip(label, onDismiss) {
+      const chip = document.createElement('span');
+      chip.className = 'inline-flex items-center gap-1.5 px-2.5 py-1 text-[11px] font-semibold bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700 rounded-full';
+      chip.appendChild(document.createTextNode(label));
+      const btn = document.createElement('button');
+      btn.textContent = '×';
+      btn.className = 'ml-0.5 text-blue-400 hover:text-blue-700 dark:hover:text-blue-200 font-bold leading-none';
+      btn.setAttribute('aria-label', `Remove ${label} filter`);
+      btn.addEventListener('click', onDismiss);
+      chip.appendChild(btn);
+      container.appendChild(chip);
+    }
+
+    if (activeCategoryIdx !== -1) makeChip(filterData[activeCategoryIdx].name, () => {
+      activeCategoryIdx = -1;
+      const sel = /** @type {HTMLSelectElement} */ (document.getElementById('filter-category'));
+      if (sel) sel.value = '';
+      updateURL(); applyFilters();
+    });
+    if (activeVersion) makeChip(activeVersion, () => {
+      activeVersion = '';
+      const sel = /** @type {HTMLSelectElement} */ (document.getElementById('filter-version'));
+      if (sel) sel.value = '';
+      updateURL(); applyFilters();
+    });
+  }
+
+  function updateURL() {
+    const params = new URLSearchParams();
+    if (activeCategoryIdx !== -1) params.set('category', slugify(filterData[activeCategoryIdx].name));
+    if (activeVersion) params.set('version', activeVersion);
+    const qs = params.toString();
+    history.pushState({}, '', qs ? `?${qs}` : location.pathname);
+  }
+
+  function readURLParams() {
+    const params = new URLSearchParams(location.search);
+    const catSlug = params.get('category');
+    const version = params.get('version');
+    if (catSlug) activeCategoryIdx = filterData.findIndex(cat => slugify(cat.name) === catSlug);
+    if (version) activeVersion = version;
+    const catSel = /** @type {HTMLSelectElement} */ (document.getElementById('filter-category'));
+    const verSel = /** @type {HTMLSelectElement} */ (document.getElementById('filter-version'));
+    if (catSel && activeCategoryIdx !== -1) catSel.value = String(activeCategoryIdx);
+    if (verSel && activeVersion) verSel.value = activeVersion;
+  }
+
+  function initFilters() {
+    populateDropdowns();
+    readURLParams();
+    applyFilters();
+
+    document.getElementById('filter-category')?.addEventListener('change', e => {
+      const val = /** @type {HTMLSelectElement} */ (e.target).value;
+      activeCategoryIdx = val === '' ? -1 : parseInt(val);
+      updateURL(); applyFilters();
+    });
+    document.getElementById('filter-version')?.addEventListener('change', e => {
+      activeVersion = /** @type {HTMLSelectElement} */ (e.target).value;
+      updateURL(); applyFilters();
+    });
+    document.getElementById('filter-clear-all')?.addEventListener('click', () => {
+      activeCategoryIdx = -1; activeVersion = '';
+      const catSel = /** @type {HTMLSelectElement} */ (document.getElementById('filter-category'));
+      const verSel = /** @type {HTMLSelectElement} */ (document.getElementById('filter-version'));
+      if (catSel) catSel.value = '';
+      if (verSel) verSel.value = '';
+      updateURL(); applyFilters();
+    });
+    window.addEventListener('popstate', () => {
+      activeCategoryIdx = -1; activeVersion = '';
+      readURLParams(); applyFilters();
+    });
+  }
+
+  initFilters();
 </script>

--- a/src/pages/schemas/[...slug].astro
+++ b/src/pages/schemas/[...slug].astro
@@ -10,8 +10,22 @@ import * as path from 'node:path';
 export async function getStaticPaths() {
     const paths = [];
     for (const [group, resources] of Object.entries(catalog.groups)) {
+        // Group-level listing page: /schemas/traefik.io
+        paths.push({
+            params: { slug: group },
+            props: {
+                pageType: 'group' as const,
+                group,
+                resources,
+                file: undefined,
+                version: undefined,
+                kind: undefined,
+                siblingVersions: undefined,
+            }
+        });
+
+        // Resource-level pages: /schemas/traefik.io/v1alpha1/ingressroute
         for (const res of resources) {
-            // Find all versions of the same kind within this group
             const siblingVersions = resources
                 .filter(r => r.kind === res.kind)
                 .map(r => ({ version: r.version, file: r.file, slug: r.slug }));
@@ -19,11 +33,13 @@ export async function getStaticPaths() {
             paths.push({
                 params: { slug: res.slug },
                 props: {
+                    pageType: 'resource' as const,
                     file: res.file,
                     group,
                     version: res.version,
                     kind: res.kind,
                     siblingVersions,
+                    resources: undefined,
                 }
             });
         }
@@ -31,65 +47,141 @@ export async function getStaticPaths() {
     return paths;
 }
 
-const { file, group, version, kind, siblingVersions } = Astro.props;
+const { pageType, group, resources, file, version, kind, siblingVersions } = Astro.props;
 
-const fullPath = path.resolve('schemas', file);
-const content = fs.readFileSync(fullPath, 'utf-8');
-let schema;
-try {
-    schema = JSON.parse(content.split('}\n{')[0] + (content.includes('}\n{') ? '}' : ''));
-} catch (e) {
-    schema = { title: kind, description: "Could not parse JSON schema" };
+let schema: any;
+let schemaDescription: string;
+
+if (pageType === 'resource') {
+    const fullPath = path.resolve('schemas', file!);
+    const content = fs.readFileSync(fullPath, 'utf-8');
+    try {
+        schema = JSON.parse(content.split('}\n{')[0] + (content.includes('}\n{') ? '}' : ''));
+    } catch (e) {
+        schema = { title: kind, description: 'Could not parse JSON schema' };
+    }
+    schemaDescription = schema.description || `Kubernetes CRD schema for ${kind} (${version}) in ${group}`;
 }
 
-const schemaDescription = schema.description || `Kubernetes CRD schema for ${kind} (${version}) in ${group}`;
+// For group page: group resources by version
+const resourcesByVersion: Record<string, typeof resources> = {};
+if (pageType === 'group' && resources) {
+    for (const res of resources) {
+        if (!resourcesByVersion[res.version]) resourcesByVersion[res.version] = [];
+        resourcesByVersion[res.version].push(res);
+    }
+}
+const sortedVersions = Object.keys(resourcesByVersion).sort((a, b) => b.localeCompare(a));
 ---
 
-<Layout title={`${kind} (${version})`} description={schemaDescription}>
-	<div class="max-w-4xl mx-auto px-6 py-12">
-		<header class="mb-12 border-b border-gray-100 dark:border-slate-800 pb-8">
-			<nav class="flex text-[11px] font-bold text-gray-400 dark:text-slate-500 mb-4 gap-2 uppercase tracking-widest flex-wrap">
-				<a href="/" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Home</a>
-				<span>/</span>
-				<a href="/" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors truncate max-w-[200px]">{group}</a>
-				<span>/</span>
-				<span class="text-blue-500 dark:text-blue-400">{version}</span>
-				<span>/</span>
-				<span class="text-gray-600 dark:text-slate-300">{kind}</span>
-			</nav>
-			<h1 class="text-4xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-4">
-				{kind}
-			</h1>
-			<p class="text-lg text-gray-600 dark:text-slate-400 leading-relaxed font-medium">
-				{schema.description || 'No description provided.'}
-			</p>
-		</header>
+{pageType === 'group' ? (
+<Layout title={group} description={`All Kubernetes CRD schemas for the ${group} API group`}>
+    <div class="max-w-4xl mx-auto px-6 py-12">
+        <header class="mb-10 border-b border-gray-100 dark:border-slate-800 pb-8">
+            <nav class="flex text-[11px] font-bold text-gray-400 dark:text-slate-500 mb-4 gap-2 uppercase tracking-widest flex-wrap">
+                <a href="/" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Home</a>
+                <span>/</span>
+                <span class="text-blue-500 dark:text-blue-400">{group}</span>
+            </nav>
+            <h1 class="text-4xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-3">
+                {group}
+            </h1>
+            <p class="text-base text-gray-500 dark:text-slate-400 font-medium">
+                {resources!.length} resource{resources!.length !== 1 ? 's' : ''} across {sortedVersions.length} version{sortedVersions.length !== 1 ? 's' : ''}
+            </p>
+        </header>
 
-		<section>
-			<SchemaViewToggle
-				client:load
-				initialSchema={schema}
-				titles={titles as any}
-				schemaJson={JSON.stringify(schema, null, 2)}
-				schemaFile={file}
-			/>
-		</section>
+        <div class="space-y-10">
+            {sortedVersions.map((ver) => (
+                <section>
+                    <div class="flex items-center gap-3 mb-4">
+                        <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-slate-500 border border-gray-200 dark:border-slate-700 rounded-lg px-2.5 py-1 bg-gray-50 dark:bg-slate-800">
+                            {ver}
+                        </span>
+                        <div class="flex-1 h-px bg-gray-100 dark:bg-slate-800"></div>
+                        <span class="text-[10px] font-bold text-gray-300 dark:text-slate-600">{resourcesByVersion[ver].length} kind{resourcesByVersion[ver].length !== 1 ? 's' : ''}</span>
+                    </div>
+                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        {resourcesByVersion[ver].map((res) => (
+                            <a
+                                href={`/schemas/${res.slug}`}
+                                class="group flex items-center justify-between px-5 py-4 bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-2xl hover:border-blue-300 dark:hover:border-blue-600 hover:shadow-md transition-all"
+                            >
+                                <div class="flex items-center gap-3 min-w-0">
+                                    <div class="w-8 h-8 rounded-lg bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center shrink-0">
+                                        <span class="text-[9px] font-black text-blue-500 dark:text-blue-400 uppercase">CRD</span>
+                                    </div>
+                                    <span class="text-sm font-semibold text-gray-900 dark:text-white group-hover:text-blue-700 dark:group-hover:text-blue-300 truncate transition-colors">
+                                        {res.kind}
+                                    </span>
+                                </div>
+                                <svg class="w-4 h-4 text-gray-300 dark:text-slate-600 group-hover:text-blue-400 shrink-0 ml-2 transition-colors" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+                                </svg>
+                            </a>
+                        ))}
+                    </div>
+                </section>
+            ))}
+        </div>
 
-		{siblingVersions.length > 1 && (
-			<SchemaDiffViewer
-				client:load
-				currentVersion={version}
-				versions={siblingVersions}
-			/>
-		)}
-
-		<footer class="mt-20 pt-8 border-t border-gray-100 dark:border-slate-800 flex justify-between items-center">
-			<div class="text-[10px] text-gray-400 dark:text-slate-500 font-bold uppercase tracking-widest">
-				OpenSpec HUB
-			</div>
-			<div class="text-[10px] text-gray-300 dark:text-slate-600 font-mono">
-				Source: {file}
-			</div>
-		</footer>
-	</div>
+        <footer class="mt-20 pt-8 border-t border-gray-100 dark:border-slate-800 flex justify-between items-center">
+            <div class="text-[10px] text-gray-400 dark:text-slate-500 font-bold uppercase tracking-widest">
+                OpenSpec HUB
+            </div>
+            <div class="text-[10px] text-gray-300 dark:text-slate-600 font-mono">
+                {group}
+            </div>
+        </footer>
+    </div>
 </Layout>
+) : (
+<Layout title={`${kind} (${version})`} description={schemaDescription}>
+    <div class="max-w-4xl mx-auto px-6 py-12">
+        <header class="mb-12 border-b border-gray-100 dark:border-slate-800 pb-8">
+            <nav class="flex text-[11px] font-bold text-gray-400 dark:text-slate-500 mb-4 gap-2 uppercase tracking-widest flex-wrap">
+                <a href="/" class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors">Home</a>
+                <span>/</span>
+                <a href={`/schemas/${group}`} class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors truncate max-w-[200px]">{group}</a>
+                <span>/</span>
+                <span class="text-blue-500 dark:text-blue-400">{version}</span>
+                <span>/</span>
+                <span class="text-gray-600 dark:text-slate-300">{kind}</span>
+            </nav>
+            <h1 class="text-4xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-4">
+                {kind}
+            </h1>
+            <p class="text-lg text-gray-600 dark:text-slate-400 leading-relaxed font-medium">
+                {schema.description || 'No description provided.'}
+            </p>
+        </header>
+
+        <section>
+            <SchemaViewToggle
+                client:load
+                initialSchema={schema}
+                titles={titles as any}
+                schemaJson={JSON.stringify(schema, null, 2)}
+                schemaFile={file!}
+            />
+        </section>
+
+        {siblingVersions!.length > 1 && (
+            <SchemaDiffViewer
+                client:load
+                currentVersion={version!}
+                versions={siblingVersions!}
+            />
+        )}
+
+        <footer class="mt-20 pt-8 border-t border-gray-100 dark:border-slate-800 flex justify-between items-center">
+            <div class="text-[10px] text-gray-400 dark:text-slate-500 font-bold uppercase tracking-widest">
+                OpenSpec HUB
+            </div>
+            <div class="text-[10px] text-gray-300 dark:text-slate-600 font-mono">
+                Source: {file}
+            </div>
+        </footer>
+    </div>
+</Layout>
+)}


### PR DESCRIPTION
## Summary

- Adds group-level listing pages at `/schemas/<group>` showing all CRDs for an API group, sectioned by version
- Makes sidebar group names clickable links with active group highlighting
- Adds client-side advanced filtering bar to home page with category and version dropdowns, filter chips, and live results count

Closes: #228