### PR TITLE
feat(schemas): add openstack resource controller crd support

### DIFF
--- a/crds/k-orc.sh
+++ b/crds/k-orc.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+export choice=individual
+export FILES=(
+  "openstack.k-orc.cloud_addressscopes.yaml"
+  "openstack.k-orc.cloud_applicationcredentials.yaml"
+  "openstack.k-orc.cloud_domains.yaml"
+  "openstack.k-orc.cloud_endpoints.yaml"
+  "openstack.k-orc.cloud_flavors.yaml"
+  "openstack.k-orc.cloud_floatingips.yaml"
+  "openstack.k-orc.cloud_groups.yaml"
+  "openstack.k-orc.cloud_images.yaml"
+  "openstack.k-orc.cloud_keypairs.yaml"
+  "openstack.k-orc.cloud_networks.yaml"
+  "openstack.k-orc.cloud_ports.yaml"
+  "openstack.k-orc.cloud_projects.yaml"
+  "openstack.k-orc.cloud_roles.yaml"
+  "openstack.k-orc.cloud_routerinterfaces.yaml"
+  "openstack.k-orc.cloud_routers.yaml"
+  "openstack.k-orc.cloud_securitygroups.yaml"
+  "openstack.k-orc.cloud_servergroups.yaml"
+  "openstack.k-orc.cloud_servers.yaml"
+  "openstack.k-orc.cloud_services.yaml"
+  "openstack.k-orc.cloud_subnets.yaml"
+  "openstack.k-orc.cloud_trunks.yaml"
+  "openstack.k-orc.cloud_users.yaml"
+  "openstack.k-orc.cloud_volumes.yaml"
+  "openstack.k-orc.cloud_volumetypes.yaml"
+)
+
+# renovate: datasource=github-tags depName=k-orc/openstack-resource-controller
+export VERSION=v2.5.0
+
+function generate_url {
+  local crd_file=$1
+  echo "https://raw.githubusercontent.com/k-orc/openstack-resource-controller/${VERSION}/config/crd/bases/${crd_file}"
+}

--- a/public/data/catalog.json
+++ b/public/data/catalog.json
@@ -13094,6 +13094,152 @@
         "slug": "opensearchservice.services.k8s.aws/v1alpha1/domain"
       }
     ],
+    "openstack.k-orc.cloud": [
+      {
+        "kind": "addressscope",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/addressscope_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/addressscope"
+      },
+      {
+        "kind": "applicationcredential",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/applicationcredential_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/applicationcredential"
+      },
+      {
+        "kind": "domain",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/domain_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/domain"
+      },
+      {
+        "kind": "endpoint",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/endpoint_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/endpoint"
+      },
+      {
+        "kind": "flavor",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/flavor_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/flavor"
+      },
+      {
+        "kind": "floatingip",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/floatingip_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/floatingip"
+      },
+      {
+        "kind": "group",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/group_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/group"
+      },
+      {
+        "kind": "image",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/image_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/image"
+      },
+      {
+        "kind": "keypair",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/keypair_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/keypair"
+      },
+      {
+        "kind": "network",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/network_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/network"
+      },
+      {
+        "kind": "port",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/port_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/port"
+      },
+      {
+        "kind": "project",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/project_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/project"
+      },
+      {
+        "kind": "role",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/role_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/role"
+      },
+      {
+        "kind": "router",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/router_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/router"
+      },
+      {
+        "kind": "routerinterface",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/routerinterface_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/routerinterface"
+      },
+      {
+        "kind": "securitygroup",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/securitygroup_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/securitygroup"
+      },
+      {
+        "kind": "server",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/server_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/server"
+      },
+      {
+        "kind": "servergroup",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/servergroup_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/servergroup"
+      },
+      {
+        "kind": "service",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/service_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/service"
+      },
+      {
+        "kind": "subnet",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/subnet_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/subnet"
+      },
+      {
+        "kind": "trunk",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/trunk_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/trunk"
+      },
+      {
+        "kind": "user",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/user_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/user"
+      },
+      {
+        "kind": "volume",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/volume_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/volume"
+      },
+      {
+        "kind": "volumetype",
+        "version": "v1alpha1",
+        "file": "openstack.k-orc.cloud/volumetype_v1alpha1.json",
+        "slug": "openstack.k-orc.cloud/v1alpha1/volumetype"
+      }
+    ],
     "opentelemetry.io": [
       {
         "kind": "instrumentation",

--- a/schemas/openstack.k-orc.cloud/addressscope_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/addressscope_v1alpha1.json
@@ -1,0 +1,299 @@
+{
+  "description": "AddressScope is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "ipVersion": {
+                  "description": "ipVersion is the IP protocol version.",
+                  "enum": [
+                    4,
+                    6
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "projectRef": {
+                  "description": "projectRef is a reference to the ORC Project which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "shared": {
+                  "description": "shared indicates whether this resource is shared across all\nprojects or not. By default, only admin users can change set\nthis value.",
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "ipVersion": {
+              "description": "ipVersion is the IP protocol version.",
+              "enum": [
+                4,
+                6
+              ],
+              "format": "int32",
+              "type": "integer",
+              "x-kubernetes-validations": [
+                {
+                  "message": "ipVersion is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "projectRef": {
+              "description": "projectRef is a reference to the ORC Project which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "projectRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "shared": {
+              "description": "shared indicates whether this resource is shared across all\nprojects or not. By default, only admin users can change set\nthis value. We can't unshared a shared address scope; Neutron\nenforces this.",
+              "type": "boolean",
+              "x-kubernetes-validations": [
+                {
+                  "message": "shared address scope can't be unshared",
+                  "rule": "!(oldSelf && !self)"
+                }
+              ]
+            }
+          },
+          "required": [
+            "ipVersion"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "ipVersion": {
+              "description": "ipVersion is the IP protocol version.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "projectID": {
+              "description": "projectID is the ID of the Project to which the resource is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "shared": {
+              "description": "shared indicates whether this resource is shared across all\nprojects or not. By default, only admin users can change set\nthis value.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/applicationcredential_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/applicationcredential_v1alpha1.json
@@ -1,0 +1,403 @@
+{
+  "description": "ApplicationCredential is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 2,
+              "properties": {
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 1024,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "userRef": {
+                  "description": "userRef is a reference to the ORC User which this resource is associated with.\nNote: Due to the nature of the OpenStack API, managing application credentials for a user different than the one ORC is authenticated against can be computationally expensive. In the worst case, all application credentials of all users have to be queried.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "required": [
+                "userRef"
+              ],
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "accessRules": {
+              "description": "accessRules is a list of fine grained access control rules",
+              "items": {
+                "description": "ApplicationCredentialAccessRule defines an access rule",
+                "minProperties": 1,
+                "properties": {
+                  "method": {
+                    "description": "method that the application credential is permitted to use for a given API endpoint",
+                    "enum": [
+                      "CONNECT",
+                      "DELETE",
+                      "GET",
+                      "HEAD",
+                      "OPTIONS",
+                      "PATCH",
+                      "POST",
+                      "PUT",
+                      "TRACE"
+                    ],
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "path that the application credential is permitted to access",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "serviceRef": {
+                    "description": "serviceRef identifier for the service that the application credential is permitted to access",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 256,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "expiresAt": {
+              "description": "expiresAt is the time of expiration for the application credential. If unset, the application credential does not expire.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "roleRefs": {
+              "description": "roleRefs may only contain roles that the user has assigned on the project. If not provided, the roles assigned to the application credential will be the same as the roles in the current token.",
+              "items": {
+                "maxLength": 253,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 256,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "secretRef": {
+              "description": "secretRef is a reference to a Secret containing the application credential secret",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            },
+            "unrestricted": {
+              "description": "unrestricted is a flag indicating whether the application credential may be used for creation or destruction of other application credentials or trusts",
+              "type": "boolean"
+            },
+            "userRef": {
+              "description": "userRef is a reference to the ORC User which this resource is associated with.\nNote: Due to the nature of the OpenStack API, managing application credentials for a user different than the one ORC is authenticated against can be computationally expensive. In the worst case, all application credentials of all users have to be queried.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "secretRef",
+            "userRef"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "ApplicationCredentialResourceSpec is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "accessRules": {
+              "description": "accessRules is a list of fine grained access control rules",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "id is the ID of this access rule",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "method": {
+                    "description": "method that the application credential is permitted to use for a given API endpoint",
+                    "maxLength": 32,
+                    "type": "string"
+                  },
+                  "path": {
+                    "description": "path that the application credential is permitted to access",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "service": {
+                    "description": "service type identifier for the service that the application credential is permitted to access",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "expiresAt": {
+              "description": "expiresAt is the time of expiration for the application credential. If unset, the application credential does not expire.",
+              "format": "date-time",
+              "type": "string"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "projectID": {
+              "description": "projectID of the project the application credential was created for and that authentication requests using this application credential will be scoped to.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "roles": {
+              "description": "roles is a list of role objects may only contain roles that the user has assigned on the project",
+              "items": {
+                "properties": {
+                  "domainID": {
+                    "description": "domainID of the domain of this role",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "id is the ID of a role",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "name of an existing role",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "unrestricted": {
+              "description": "unrestricted is a flag indicating whether the application credential may be used for creation or destruction of other application credentials or trusts",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/domain_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/domain_v1alpha1.json
@@ -1,0 +1,247 @@
+{
+  "description": "Domain is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "enabled": {
+                  "description": "enabled defines whether a domain is enabled or not. Default is true.\nNote: Users can only authorize against an enabled domain (and any of its projects).",
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 64,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "enabled": {
+              "description": "enabled defines whether a domain is enabled or not. Default is true.\nNote: Users can only authorize against an enabled domain (and any of its projects).",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "enabled": {
+              "description": "enabled defines whether a domain is enabled or not. Default is true.\nNote: Users can only authorize against an enabled domain (and any of its projects).",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/endpoint_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/endpoint_v1alpha1.json
@@ -1,0 +1,299 @@
+{
+  "description": "Endpoint is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "interface": {
+                  "description": "interface of the existing endpoint.",
+                  "enum": [
+                    "admin",
+                    "internal",
+                    "public"
+                  ],
+                  "type": "string"
+                },
+                "serviceRef": {
+                  "description": "serviceRef is a reference to the ORC Service which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "url": {
+                  "description": "url is the URL of the existing endpoint.",
+                  "maxLength": 1024,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "description is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "enabled": {
+              "description": "enabled indicates whether the endpoint is enabled or not.",
+              "type": "boolean"
+            },
+            "interface": {
+              "description": "interface indicates the visibility of the endpoint.",
+              "enum": [
+                "admin",
+                "internal",
+                "public"
+              ],
+              "type": "string"
+            },
+            "serviceRef": {
+              "description": "serviceRef is a reference to the ORC Service which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "serviceRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "url": {
+              "description": "url is the endpoint URL.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "required": [
+            "interface",
+            "serviceRef",
+            "url"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "enabled": {
+              "description": "enabled indicates whether the endpoint is enabled or not.",
+              "type": "boolean"
+            },
+            "interface": {
+              "description": "interface indicates the visibility of the endpoint.",
+              "maxLength": 128,
+              "type": "string"
+            },
+            "serviceID": {
+              "description": "serviceID is the ID of the Service to which the resource is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "url": {
+              "description": "url is the endpoint URL.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/flavor_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/flavor_v1alpha1.json
@@ -1,0 +1,329 @@
+{
+  "description": "Flavor is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "disk": {
+                  "description": "disk is the size of the root disk in GiB.",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "ram": {
+                  "description": "ram is the memory of the flavor, measured in MB.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "vcpus": {
+                  "description": "vcpus is the number of vcpus for the flavor.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description contains a free form description of the flavor.",
+              "maxLength": 65535,
+              "minLength": 1,
+              "type": "string"
+            },
+            "disk": {
+              "description": "disk is the size of the root disk that will be created in GiB. If 0\nthe root disk will be set to exactly the size of the image used to\ndeploy the instance. However, in this case the scheduler cannot\nselect the compute host based on the virtual image size. Therefore,\n0 should only be used for volume booted instances or for testing\npurposes. Volume-backed instances can be enforced for flavors with\nzero root disk via the\nos_compute_api:servers:create:zero_disk_flavor policy rule.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "ephemeral": {
+              "description": "ephemeral is the size of the ephemeral disk that will be created, in GiB.\nEphemeral disks may be written over on server state changes. So should only\nbe used as a scratch space for applications that are aware of its\nlimitations. Defaults to 0.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "isPublic": {
+              "description": "isPublic flags a flavor as being available to all projects or not.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "ram": {
+              "description": "ram is the memory of the flavor, measured in MB.",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "swap": {
+              "description": "swap is the size of a dedicated swap disk that will be allocated, in\nMiB. If 0 (the default), no dedicated swap disk will be created.",
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "vcpus": {
+              "description": "vcpus is the number of vcpus for the flavor.",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "disk",
+            "ram",
+            "vcpus"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "FlavorResourceSpec is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 65535,
+              "type": "string"
+            },
+            "disk": {
+              "description": "disk is the size of the root disk that will be created in GiB.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "ephemeral": {
+              "description": "ephemeral is the size of the ephemeral disk, in GiB.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "isPublic": {
+              "description": "isPublic flags a flavor as being available to all projects or not.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the flavor. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "ram": {
+              "description": "ram is the memory of the flavor, measured in MB.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "swap": {
+              "description": "swap is the size of a dedicated swap disk that will be allocated, in\nMiB.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "vcpus": {
+              "description": "vcpus is the number of vcpus for the flavor.",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/floatingip_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/floatingip_v1alpha1.json
@@ -1,0 +1,456 @@
+{
+  "description": "FloatingIP is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "floatingIP": {
+                  "description": "floatingIP is the floatingip address.",
+                  "maxLength": 45,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "floatingNetworkRef": {
+                  "description": "floatingNetworkRef is a reference to the ORC Network which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "notTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "notTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "portRef": {
+                  "description": "portRef is a reference to the ORC Port which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "projectRef": {
+                  "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "status": {
+                  "description": "status is the status of the floatingip.",
+                  "maxLength": 1024,
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "tagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "fixedIP": {
+              "description": "fixedIP is the IP address of the port to which the floatingip is associated.",
+              "maxLength": 45,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "fixedIP is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "floatingIP": {
+              "description": "floatingIP is the IP that will be assigned to the floatingip. If not set, it will\nbe assigned automatically.",
+              "maxLength": 45,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "floatingIP is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "floatingNetworkRef": {
+              "description": "floatingNetworkRef references the network to which the floatingip is associated.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "floatingNetworkRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "floatingSubnetRef": {
+              "description": "floatingSubnetRef references the subnet to which the floatingip is associated.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "floatingSubnetRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "portRef": {
+              "description": "portRef is a reference to the ORC Port which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "portRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "projectRef": {
+              "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "projectRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "tags": {
+              "description": "tags is a list of tags which will be applied to the floatingip.",
+              "items": {
+                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "Exactly one of 'floatingNetworkRef' or 'floatingSubnetRef' must be set",
+              "rule": "has(self.floatingNetworkRef) != has(self.floatingSubnetRef)"
+            }
+          ]
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "createdAt": {
+              "description": "createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "fixedIP": {
+              "description": "fixedIP is the IP address of the port to which the floatingip is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "floatingIP": {
+              "description": "floatingIP is the IP address of the floatingip.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "floatingNetworkID": {
+              "description": "floatingNetworkID is the ID of the network to which the floatingip is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "portID": {
+              "description": "portID is the ID of the port to which the floatingip is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "projectID": {
+              "description": "projectID is the project owner of the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "revisionNumber": {
+              "description": "revisionNumber optionally set via extensions/standard-attr-revisions",
+              "format": "int64",
+              "type": "integer"
+            },
+            "routerID": {
+              "description": "routerID is the ID of the router to which the floatingip is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "status": {
+              "description": "status indicates the current status of the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "tags": {
+              "description": "tags is the list of tags on the resource.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "tenantID": {
+              "description": "tenantID is the project owner of the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "updatedAt": {
+              "description": "updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/group_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/group_v1alpha1.json
@@ -1,0 +1,258 @@
+{
+  "description": "Group is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "domainRef": {
+                  "description": "domainRef is a reference to the ORC Domain which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 64,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "domainRef": {
+              "description": "domainRef is a reference to the ORC Domain which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "domainRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "domainID": {
+              "description": "domainID is the ID of the Domain to which the resource is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/image_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/image_v1alpha1.json
@@ -1,0 +1,653 @@
+{
+  "description": "Image is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "name": {
+                  "description": "name specifies the name of a Glance image",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "tags is the list of tags on the resource.",
+                  "items": {
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "visibility": {
+                  "description": "visibility specifies the visibility of a Glance image.",
+                  "enum": [
+                    "public",
+                    "private",
+                    "shared",
+                    "community"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "content": {
+              "description": "content specifies how to obtain the image content.",
+              "properties": {
+                "containerFormat": {
+                  "default": "bare",
+                  "description": "containerFormat is the format of the image container.\nqcow2 and raw images do not usually have a container. This is specified as \"bare\", which is also the default.\nPermitted values are ami, ari, aki, bare, compressed, ovf, ova, and docker.",
+                  "enum": [
+                    "ami",
+                    "ari",
+                    "aki",
+                    "bare",
+                    "ovf",
+                    "ova",
+                    "docker",
+                    "compressed"
+                  ],
+                  "type": "string"
+                },
+                "diskFormat": {
+                  "description": "diskFormat is the format of the disk image.\nNormal values are \"qcow2\", or \"raw\". Glance may be configured to support others.",
+                  "enum": [
+                    "ami",
+                    "ari",
+                    "aki",
+                    "vhd",
+                    "vhdx",
+                    "vmdk",
+                    "raw",
+                    "qcow2",
+                    "vdi",
+                    "ploop",
+                    "iso"
+                  ],
+                  "type": "string"
+                },
+                "download": {
+                  "description": "download describes how to obtain image data by downloading it from a URL.\nMust be set when creating a managed image.",
+                  "properties": {
+                    "decompress": {
+                      "description": "decompress specifies that the source data must be decompressed with the\ngiven compression algorithm before being stored. Specifying Decompress\nwill disable the use of Glance's web-download, as web-download cannot\ncurrently deterministically decompress downloaded content.",
+                      "enum": [
+                        "xz",
+                        "gz",
+                        "bz2"
+                      ],
+                      "type": "string"
+                    },
+                    "hash": {
+                      "description": "hash is a hash which will be used to verify downloaded data, i.e.\nbefore any decompression. If not specified, no hash verification will be\nperformed. Specifying a Hash will disable the use of Glance's\nweb-download, as web-download cannot currently deterministically verify\nthe hash of downloaded content.",
+                      "properties": {
+                        "algorithm": {
+                          "description": "algorithm is the hash algorithm used to generate value.",
+                          "enum": [
+                            "md5",
+                            "sha1",
+                            "sha256",
+                            "sha512"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "value is the hash of the image data using Algorithm. It must be hex encoded using lowercase letters.",
+                          "maxLength": 1024,
+                          "minLength": 1,
+                          "pattern": "^[0-9a-f]+$",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "algorithm",
+                        "value"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "hash is immutable",
+                          "rule": "self == oldSelf"
+                        }
+                      ]
+                    },
+                    "url": {
+                      "description": "url containing image data",
+                      "format": "uri",
+                      "maxLength": 2048,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "url"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "diskFormat",
+                "download"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "content is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "name": {
+              "description": "name will be the name of the created Glance image. If not specified, the\nname of the Image object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "properties": {
+              "description": "properties is metadata available to consumers of the image",
+              "properties": {
+                "architecture": {
+                  "description": "architecture is the CPU architecture that must be supported by the hypervisor.",
+                  "enum": [
+                    "aarch64",
+                    "alpha",
+                    "armv7l",
+                    "cris",
+                    "i686",
+                    "ia64",
+                    "lm32",
+                    "m68k",
+                    "microblaze",
+                    "microblazeel",
+                    "mips",
+                    "mipsel",
+                    "mips64",
+                    "mips64el",
+                    "openrisc",
+                    "parisc",
+                    "parisc64",
+                    "ppc",
+                    "ppc64",
+                    "ppcemb",
+                    "s390",
+                    "s390x",
+                    "sh4",
+                    "sh4eb",
+                    "sparc",
+                    "sparc64",
+                    "unicore32",
+                    "x86_64",
+                    "xtensa",
+                    "xtensaeb"
+                  ],
+                  "type": "string"
+                },
+                "hardware": {
+                  "description": "hardware is a set of properties which control the virtual hardware\ncreated by Nova.",
+                  "properties": {
+                    "cdromBus": {
+                      "description": "cdromBus specifies the type of disk controller to attach CD-ROM devices to.",
+                      "enum": [
+                        "scsi",
+                        "virtio",
+                        "uml",
+                        "xen",
+                        "ide",
+                        "usb",
+                        "lxc"
+                      ],
+                      "type": "string"
+                    },
+                    "cpuCores": {
+                      "description": "cpuCores is the preferred number of cores to expose to the guest",
+                      "format": "int32",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "cpuPolicy": {
+                      "description": "cpuPolicy is used to pin the virtual CPUs (vCPUs) of instances to the\nhost's physical CPU cores (pCPUs). Host aggregates should be used to\nseparate these pinned instances from unpinned instances as the latter\nwill not respect the resourcing requirements of the former.\n\nPermitted values are shared (the default), and dedicated.\n\nshared: The guest vCPUs will be allowed to freely float across host\npCPUs, albeit potentially constrained by NUMA policy.\n\ndedicated: The guest vCPUs will be strictly pinned to a set of host\npCPUs. In the absence of an explicit vCPU topology request, the\ndrivers typically expose all vCPUs as sockets with one core and one\nthread. When strict CPU pinning is in effect the guest CPU topology\nwill be setup to match the topology of the CPUs to which it is\npinned. This option implies an overcommit ratio of 1.0. For example,\nif a two vCPU guest is pinned to a single host core with two threads,\nthen the guest will get a topology of one socket, one core, two\nthreads.",
+                      "enum": [
+                        "shared",
+                        "dedicated"
+                      ],
+                      "type": "string"
+                    },
+                    "cpuSockets": {
+                      "description": "cpuSockets is the preferred number of sockets to expose to the guest",
+                      "format": "int32",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "cpuThreadPolicy": {
+                      "description": "cpuThreadPolicy further refines a CPUPolicy of 'dedicated' by stating\nhow hardware CPU threads in a simultaneous multithreading-based (SMT)\narchitecture be used. SMT-based architectures include Intel\nprocessors with Hyper-Threading technology. In these architectures,\nprocessor cores share a number of components with one or more other\ncores. Cores in such architectures are commonly referred to as\nhardware threads, while the cores that a given core share components\nwith are known as thread siblings.\n\nPermitted values are prefer (the default), isolate, and require.\n\nprefer: The host may or may not have an SMT architecture. Where an\nSMT architecture is present, thread siblings are preferred.\n\nisolate: The host must not have an SMT architecture or must emulate a\nnon-SMT architecture. If the host does not have an SMT architecture,\neach vCPU is placed on a different core as expected. If the host does\nhave an SMT architecture - that is, one or more cores have thread\nsiblings - then each vCPU is placed on a different physical core. No\nvCPUs from other guests are placed on the same core. All but one\nthread sibling on each utilized core is therefore guaranteed to be\nunusable.\n\nrequire: The host must have an SMT architecture. Each vCPU is\nallocated on thread siblings. If the host does not have an SMT\narchitecture, then it is not used. If the host has an SMT\narchitecture, but not enough cores with free thread siblings are\navailable, then scheduling fails.",
+                      "enum": [
+                        "prefer",
+                        "isolate",
+                        "require"
+                      ],
+                      "type": "string"
+                    },
+                    "cpuThreads": {
+                      "description": "cpuThreads is the preferred number of threads to expose to the guest",
+                      "format": "int32",
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "diskBus": {
+                      "description": "diskBus specifies the type of disk controller to attach disk devices to.",
+                      "enum": [
+                        "scsi",
+                        "virtio",
+                        "uml",
+                        "xen",
+                        "ide",
+                        "usb",
+                        "lxc"
+                      ],
+                      "type": "string"
+                    },
+                    "qemuGuestAgent": {
+                      "description": "qemuGuestAgent enables QEMU guest agent.",
+                      "type": "boolean"
+                    },
+                    "rngModel": {
+                      "description": "rngModel adds a random-number generator device to the image’s instances.\nThis image property by itself does not guarantee that a hardware RNG will be used;\nit expresses a preference that may or may not be satisfied depending upon Nova configuration.",
+                      "maxLength": 255,
+                      "type": "string"
+                    },
+                    "scsiModel": {
+                      "description": "scsiModel enables the use of VirtIO SCSI (virtio-scsi) to provide\nblock device access for compute instances; by default, instances use\nVirtIO Block (virtio-blk). VirtIO SCSI is a para-virtualized SCSI\ncontroller device that provides improved scalability and performance,\nand supports advanced SCSI hardware.\n\nThe only permitted value is virtio-scsi.",
+                      "enum": [
+                        "virtio-scsi"
+                      ],
+                      "type": "string"
+                    },
+                    "vifModel": {
+                      "description": "vifModel specifies the model of virtual network interface device to use.\n\nPermitted values are e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio,\nand vmxnet3.",
+                      "enum": [
+                        "e1000",
+                        "e1000e",
+                        "ne2k_pci",
+                        "pcnet",
+                        "rtl8139",
+                        "virtio",
+                        "vmxnet3"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "hypervisorType": {
+                  "description": "hypervisorType is the hypervisor type",
+                  "enum": [
+                    "hyperv",
+                    "ironic",
+                    "lxc",
+                    "qemu",
+                    "uml",
+                    "vmware",
+                    "xen"
+                  ],
+                  "type": "string"
+                },
+                "minDiskGB": {
+                  "description": "minDiskGB is the minimum amount of disk space in GB that is required to boot the image",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "minMemoryMB": {
+                  "description": "minMemoryMB is the minimum amount of RAM in MB that is required to boot the image.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "operatingSystem": {
+                  "description": "operatingSystem is a set of properties that specify and influence the behavior\nof the operating system within the virtual machine.",
+                  "properties": {
+                    "distro": {
+                      "description": "distro is the common name of the operating system distribution in lowercase.",
+                      "enum": [
+                        "arch",
+                        "centos",
+                        "debian",
+                        "fedora",
+                        "freebsd",
+                        "gentoo",
+                        "mandrake",
+                        "mandriva",
+                        "mes",
+                        "msdos",
+                        "netbsd",
+                        "netware",
+                        "openbsd",
+                        "opensolaris",
+                        "opensuse",
+                        "rocky",
+                        "rhel",
+                        "sled",
+                        "ubuntu",
+                        "windows"
+                      ],
+                      "type": "string"
+                    },
+                    "version": {
+                      "description": "version is the operating system version as specified by the distributor.",
+                      "maxLength": 255,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "properties is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "protected": {
+              "description": "protected specifies that the image is protected from deletion.\nIf not specified, the default is false.",
+              "type": "boolean"
+            },
+            "tags": {
+              "description": "tags is a list of tags which will be applied to the image. A tag has a maximum length of 255 characters.",
+              "items": {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
+            "visibility": {
+              "description": "visibility of the image",
+              "enum": [
+                "public",
+                "private",
+                "shared",
+                "community"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        },
+        {
+          "message": "resource content must be specified when not importing",
+          "rule": "!has(self.__import__) ? has(self.resource.content) : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "downloadAttempts": {
+          "description": "downloadAttempts is the number of times the controller has attempted to download the image contents",
+          "format": "int32",
+          "type": "integer"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "hash": {
+              "description": "hash is the hash of the image data published by Glance. Note that this is\na hash of the data stored internally by Glance, which will have been\ndecompressed and potentially format converted depending on server-side\nconfiguration which is not visible to clients. It is expected that this\nhash will usually differ from the download hash.",
+              "properties": {
+                "algorithm": {
+                  "description": "algorithm is the hash algorithm used to generate value.",
+                  "enum": [
+                    "md5",
+                    "sha1",
+                    "sha256",
+                    "sha512"
+                  ],
+                  "type": "string"
+                },
+                "value": {
+                  "description": "value is the hash of the image data using Algorithm. It must be hex encoded using lowercase letters.",
+                  "maxLength": 1024,
+                  "minLength": 1,
+                  "pattern": "^[0-9a-f]+$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "algorithm",
+                "value"
+              ],
+              "type": "object"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the image. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "protected": {
+              "description": "protected specifies that the image is protected from deletion.",
+              "type": "boolean"
+            },
+            "sizeB": {
+              "description": "sizeB is the size of the image data, in bytes",
+              "format": "int64",
+              "type": "integer"
+            },
+            "status": {
+              "description": "status is the image status as reported by Glance",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "tags": {
+              "description": "tags is the list of tags on the resource.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "virtualSizeB": {
+              "description": "virtualSizeB is the size of the disk the image data represents, in bytes",
+              "format": "int64",
+              "type": "integer"
+            },
+            "visibility": {
+              "description": "visibility of the image",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/keypair_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/keypair_v1alpha1.json
@@ -1,0 +1,257 @@
+{
+  "description": "KeyPair is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "name": {
+                  "description": "name of the existing Keypair",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the name of an existing resource. Note: This resource uses\nthe resource name as the unique identifier, not a UUID.\nWhen specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "publicKey": {
+              "description": "publicKey is the public key to import.",
+              "maxLength": 16384,
+              "minLength": 1,
+              "type": "string"
+            },
+            "type": {
+              "description": "type specifies the type of the Keypair. Allowed values are ssh or x509.\nIf not specified, defaults to ssh.",
+              "enum": [
+                "ssh",
+                "x509"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "publicKey"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "fingerprint": {
+              "description": "fingerprint is the fingerprint of the public key",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "publicKey": {
+              "description": "publicKey is the public key of the Keypair",
+              "maxLength": 16384,
+              "type": "string"
+            },
+            "type": {
+              "description": "type is the type of the Keypair (ssh or x509)",
+              "maxLength": 64,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/network_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/network_v1alpha1.json
@@ -1,0 +1,480 @@
+{
+  "description": "Network is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "external": {
+                  "description": "external indicates whether the network has an external routing\nfacility that’s not managed by the networking service.",
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "notTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "notTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "projectRef": {
+                  "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "tagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "adminStateUp": {
+              "description": "adminStateUp is the administrative state of the network, which is up (true) or down (false)",
+              "type": "boolean"
+            },
+            "availabilityZoneHints": {
+              "description": "availabilityZoneHints is the availability zone candidate for the network.",
+              "items": {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set",
+              "x-kubernetes-validations": [
+                {
+                  "message": "availabilityZoneHints is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "dnsDomain": {
+              "description": "dnsDomain is the DNS domain of the network",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[A-Za-z0-9]{1,63}(.[A-Za-z0-9-]{1,63})*(.[A-Za-z]{2,63})*.?$",
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "dnsDomain is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "external": {
+              "description": "external indicates whether the network has an external routing\nfacility that’s not managed by the networking service.",
+              "type": "boolean"
+            },
+            "mtu": {
+              "description": "mtu is the the maximum transmission unit value to address\nfragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.\nDefaults to 1500.",
+              "format": "int32",
+              "maximum": 9216,
+              "minimum": 68,
+              "type": "integer"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "portSecurityEnabled": {
+              "description": "portSecurityEnabled is the port security status of the network.\nValid values are enabled (true) and disabled (false). This value is\nused as the default value of port_security_enabled field of a newly\ncreated port.",
+              "type": "boolean"
+            },
+            "projectRef": {
+              "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "projectRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "shared": {
+              "description": "shared indicates whether this resource is shared across all\nprojects. By default, only administrative users can change this\nvalue.",
+              "type": "boolean"
+            },
+            "tags": {
+              "description": "tags is a list of tags which will be applied to the network.",
+              "items": {
+                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "adminStateUp": {
+              "description": "adminStateUp is the administrative state of the network,\nwhich is up (true) or down (false).",
+              "type": "boolean"
+            },
+            "availabilityZoneHints": {
+              "description": "availabilityZoneHints is the availability zone candidate for the\nnetwork.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "createdAt": {
+              "description": "createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "dnsDomain": {
+              "description": "dnsDomain is the DNS domain of the network",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "external": {
+              "description": "external defines whether the network may be used for creation of\nfloating IPs. Only networks with this flag may be an external\ngateway for routers. The network must have an external routing\nfacility that is not managed by the networking service. If the\nnetwork is updated from external to internal the unused floating IPs\nof this network are automatically deleted when extension\nfloatingip-autodelete-internal is present.",
+              "type": "boolean"
+            },
+            "mtu": {
+              "description": "mtu is the the maximum transmission unit value to address\nfragmentation. Minimum value is 68 for IPv4, and 1280 for IPv6.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the network. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "portSecurityEnabled": {
+              "description": "portSecurityEnabled is the port security status of the network.\nValid values are enabled (true) and disabled (false). This value is\nused as the default value of port_security_enabled field of a newly\ncreated port.",
+              "type": "boolean"
+            },
+            "projectID": {
+              "description": "projectID is the project owner of the network.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "provider": {
+              "description": "provider contains provider-network properties.",
+              "properties": {
+                "networkType": {
+                  "description": "networkType is the type of physical network that this\nnetwork should be mapped to. Supported values are flat, vlan, vxlan, and gre.\nValid values depend on the networking back-end.",
+                  "maxLength": 1024,
+                  "type": "string"
+                },
+                "physicalNetwork": {
+                  "description": "physicalNetwork is the physical network where this network\nshould be implemented. The Networking API v2.0 does not provide a\nway to list available physical networks. For example, the Open\nvSwitch plug-in configuration file defines a symbolic name that maps\nto specific bridges on each compute host.",
+                  "maxLength": 1024,
+                  "type": "string"
+                },
+                "segmentationID": {
+                  "description": "segmentationID is the ID of the isolated segment on the\nphysical network. The network_type attribute defines the\nsegmentation model. For example, if the network_type value is vlan,\nthis ID is a vlan identifier. If the network_type value is gre, this\nID is a gre key.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "revisionNumber": {
+              "description": "revisionNumber optionally set via extensions/standard-attr-revisions",
+              "format": "int64",
+              "type": "integer"
+            },
+            "shared": {
+              "description": "shared specifies whether the network resource can be accessed by any\ntenant.",
+              "type": "boolean"
+            },
+            "status": {
+              "description": "status indicates whether network is currently operational. Possible values\ninclude `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define\nadditional values.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "subnets": {
+              "description": "subnets associated with this network.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 256,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "tags": {
+              "description": "tags is the list of tags on the resource.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "updatedAt": {
+              "description": "updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/port_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/port_v1alpha1.json
@@ -1,0 +1,620 @@
+{
+  "description": "Port is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "adminStateUp": {
+                  "description": "adminStateUp is the administrative state of the port,\nwhich is up (true) or down (false).",
+                  "type": "boolean"
+                },
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "macAddress": {
+                  "description": "macAddress is the MAC address of the port.",
+                  "maxLength": 32,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "networkRef": {
+                  "description": "networkRef is a reference to the ORC Network which this port is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "notTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "notTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "projectRef": {
+                  "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "tagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "addresses": {
+              "description": "addresses are the IP addresses for the port.",
+              "items": {
+                "properties": {
+                  "ip": {
+                    "description": "ip contains a fixed IP address assigned to the port. It must belong\nto the referenced subnet's CIDR. If not specified, OpenStack\nallocates an available IP from the referenced subnet.",
+                    "maxLength": 45,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "subnetRef": {
+                    "description": "subnetRef references the subnet from which to allocate the IP\naddress.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "subnetRef"
+                ],
+                "type": "object"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic",
+              "x-kubernetes-validations": [
+                {
+                  "message": "addresses is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "adminStateUp": {
+              "default": true,
+              "description": "adminStateUp is the administrative state of the port,\nwhich is up (true) or down (false). The default value is true.",
+              "type": "boolean"
+            },
+            "allowedAddressPairs": {
+              "description": "allowedAddressPairs are allowed addresses associated with this port.",
+              "items": {
+                "properties": {
+                  "ip": {
+                    "description": "ip contains an IP address which a server connected to the port can\nsend packets with. It can be an IP Address or a CIDR (if supported\nby the underlying extension plugin).",
+                    "maxLength": 45,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "mac": {
+                    "description": "mac contains a MAC address which a server connected to the port can\nsend packets with. Defaults to the MAC address of the port.",
+                    "maxLength": 17,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ip"
+                ],
+                "type": "object"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "hostID": {
+              "description": "hostID specifies the host where the port will be bound.\nNote that when the port is attached to a server, OpenStack may\nrebind the port to the server's actual compute host, which may\ndiffer from the specified hostID if no matching scheduler hint\nis used. In this case the port's status will reflect the actual\nbinding host, not the value specified here.",
+              "maxProperties": 1,
+              "minProperties": 1,
+              "properties": {
+                "id": {
+                  "description": "id is the literal host ID string to use for binding:host_id.\nThis is mutually exclusive with serverRef.",
+                  "maxLength": 36,
+                  "type": "string"
+                },
+                "serverRef": {
+                  "description": "serverRef is a reference to an ORC Server resource from which to\nretrieve the hostID for port binding. The hostID will be read from\nthe Server's status.resource.hostID field.\nThis is mutually exclusive with id.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "hostID is immutable",
+                  "rule": "self == oldSelf"
+                },
+                {
+                  "message": "exactly one of id or serverRef must be set",
+                  "rule": "(has(self.id) && size(self.id) > 0) != (has(self.serverRef) && size(self.serverRef) > 0)"
+                }
+              ]
+            },
+            "macAddress": {
+              "description": "macAddress is the MAC address of the port.",
+              "maxLength": 32,
+              "type": "string"
+            },
+            "name": {
+              "description": "name is a human-readable name of the port. If not set, the object's name will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "networkRef": {
+              "description": "networkRef is a reference to the ORC Network which this port is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "networkRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "portSecurity": {
+              "default": "Inherit",
+              "description": "portSecurity controls port security for this port.\nWhen set to Enabled, port security is enabled.\nWhen set to Disabled, port security is disabled and SecurityGroupRefs must be empty.\nWhen set to Inherit (default), it takes the value from the network level.",
+              "enum": [
+                "Enabled",
+                "Disabled",
+                "Inherit"
+              ],
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "portSecurity cannot be changed to Inherit",
+                  "rule": "!(oldSelf != 'Inherit' && self == 'Inherit')"
+                }
+              ]
+            },
+            "projectRef": {
+              "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "projectRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "securityGroupRefs": {
+              "description": "securityGroupRefs are the names of the security groups associated\nwith this port.",
+              "items": {
+                "maxLength": 255,
+                "minLength": 1,
+                "pattern": "^[^,]+$",
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
+            "tags": {
+              "description": "tags is a list of tags which will be applied to the port.",
+              "items": {
+                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
+            "vnicType": {
+              "description": "vnicType specifies the type of vNIC which this port should be\nattached to. This is used to determine which mechanism driver(s) to\nbe used to bind the port. The valid values are normal, macvtap,\ndirect, baremetal, direct-physical, virtio-forwarder, smart-nic and\nremote-managed, although these values will not be validated in this\nAPI to ensure compatibility with future neutron changes or custom\nimplementations. What type of vNIC is actually available depends on\ndeployments. If not specified, the Neutron default value is used.",
+              "maxLength": 64,
+              "type": "string"
+            }
+          },
+          "required": [
+            "networkRef"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "securityGroupRefs must be empty when portSecurity is set to Disabled",
+              "rule": "has(self.portSecurity) && self.portSecurity == 'Disabled' ? !has(self.securityGroupRefs) : true"
+            },
+            {
+              "message": "allowedAddressPairs must be empty when portSecurity is set to Disabled",
+              "rule": "has(self.portSecurity) && self.portSecurity == 'Disabled' ? !has(self.allowedAddressPairs) : true"
+            }
+          ]
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "adminStateUp": {
+              "description": "adminStateUp is the administrative state of the port,\nwhich is up (true) or down (false).",
+              "type": "boolean"
+            },
+            "allowedAddressPairs": {
+              "description": "allowedAddressPairs is a set of zero or more allowed address pair\nobjects each where address pair object contains an IP address and\nMAC address.",
+              "items": {
+                "properties": {
+                  "ip": {
+                    "description": "ip contains an IP address which a server connected to the port can\nsend packets with.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "mac": {
+                    "description": "mac contains a MAC address which a server connected to the port can\nsend packets with.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "createdAt": {
+              "description": "createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "deviceID": {
+              "description": "deviceID is the ID of the device that uses this port.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "deviceOwner": {
+              "description": "deviceOwner is the entity type that uses this port.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "fixedIPs": {
+              "description": "fixedIPs is a set of zero or more fixed IP objects each where fixed\nIP object contains an IP address and subnet ID from which the IP\naddress is assigned.",
+              "items": {
+                "properties": {
+                  "ip": {
+                    "description": "ip contains a fixed IP address assigned to the port.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "subnetID": {
+                    "description": "subnetID is the ID of the subnet this IP is allocated from.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "hostID": {
+              "description": "hostID is the ID of host where the port resides.",
+              "maxLength": 128,
+              "type": "string"
+            },
+            "macAddress": {
+              "description": "macAddress is the MAC address of the port.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "name": {
+              "description": "name is the human-readable name of the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "networkID": {
+              "description": "networkID is the ID of the attached network.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "portSecurityEnabled": {
+              "description": "portSecurityEnabled indicates whether port security is enabled or not.",
+              "type": "boolean"
+            },
+            "projectID": {
+              "description": "projectID is the project owner of the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "propagateUplinkStatus": {
+              "description": "propagateUplinkStatus represents the uplink status propagation of\nthe port.",
+              "type": "boolean"
+            },
+            "revisionNumber": {
+              "description": "revisionNumber optionally set via extensions/standard-attr-revisions",
+              "format": "int64",
+              "type": "integer"
+            },
+            "securityGroups": {
+              "description": "securityGroups contains the IDs of security groups applied to the port.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "status": {
+              "description": "status indicates the current status of the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "tags": {
+              "description": "tags is the list of tags on the resource.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "updatedAt": {
+              "description": "updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            },
+            "vnicType": {
+              "description": "vnicType is the type of vNIC which this port is attached to.",
+              "maxLength": 64,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/project_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/project_v1alpha1.json
@@ -1,0 +1,331 @@
+{
+  "description": "Project is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "domainRef": {
+                  "description": "domainRef is a reference to the ORC Domain which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 64,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "notTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 80,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "notTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 80,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 80,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "tagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 80,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description contains a free form description of the project.",
+              "maxLength": 65535,
+              "minLength": 1,
+              "type": "string"
+            },
+            "domainRef": {
+              "description": "domainRef is a reference to the ORC Domain which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "domainRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "enabled": {
+              "description": "enabled defines whether a project is enabled or not. Default is true.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            },
+            "tags": {
+              "description": "tags is list of simple strings assigned to a project.\nTags can be used to classify projects into groups.",
+              "items": {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 80,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 65535,
+              "type": "string"
+            },
+            "domainID": {
+              "description": "domainID is the ID of the Domain to which the resource is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "enabled": {
+              "description": "enabled represents whether a project is enabled or not.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the project. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "tags": {
+              "description": "tags is the list of tags on the resource.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 80,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/role_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/role_v1alpha1.json
@@ -1,0 +1,258 @@
+{
+  "description": "Role is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "domainRef": {
+                  "description": "domainRef is a reference to the ORC Domain which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 64,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "domainRef": {
+              "description": "domainRef is a reference to the ORC Domain which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "domainRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 64,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "domainID": {
+              "description": "domainID is the ID of the Domain to which the resource is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/router_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/router_v1alpha1.json
@@ -1,0 +1,428 @@
+{
+  "description": "Router is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "notTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "notTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "projectRef": {
+                  "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "tagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "adminStateUp": {
+              "description": "adminStateUp represents the administrative state of the resource,\nwhich is up (true) or down (false). Default is true.",
+              "type": "boolean"
+            },
+            "availabilityZoneHints": {
+              "description": "availabilityZoneHints is the availability zone candidate for the router.",
+              "items": {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set",
+              "x-kubernetes-validations": [
+                {
+                  "message": "availabilityZoneHints is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "distributed": {
+              "description": "distributed indicates whether the router is distributed or not. It\nis available when dvr extension is enabled.",
+              "type": "boolean",
+              "x-kubernetes-validations": [
+                {
+                  "message": "distributed is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "externalGateways": {
+              "description": "externalGateways is a list of external gateways for the router.\nMultiple gateways are not currently supported by ORC.",
+              "items": {
+                "properties": {
+                  "networkRef": {
+                    "description": "networkRef is a reference to the ORC Network which the external\ngateway is on.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "networkRef"
+                ],
+                "type": "object"
+              },
+              "maxItems": 1,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic",
+              "x-kubernetes-validations": [
+                {
+                  "message": "externalGateways is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "name": {
+              "description": "name is a human-readable name of the router. If not set, the\nobject's name will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "projectRef": {
+              "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "projectRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "tags": {
+              "description": "tags is a list of tags which will be applied to the router.",
+              "items": {
+                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "adminStateUp": {
+              "description": "adminStateUp is the administrative state of the router,\nwhich is up (true) or down (false).",
+              "type": "boolean"
+            },
+            "availabilityZoneHints": {
+              "description": "availabilityZoneHints is the availability zone candidate for the\nrouter.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "externalGateways": {
+              "description": "externalGateways is a list of external gateways for the router.",
+              "items": {
+                "properties": {
+                  "networkID": {
+                    "description": "networkID is the ID of the network the gateway is on.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 32,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "name": {
+              "description": "name is the human-readable name of the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "projectID": {
+              "description": "projectID is the project owner of the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "status": {
+              "description": "status indicates the current status of the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "tags": {
+              "description": "tags is the list of tags on the resource.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/routerinterface_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/routerinterface_v1alpha1.json
@@ -1,0 +1,132 @@
+{
+  "description": "RouterInterface is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "routerRef": {
+          "description": "routerRef references the router to which this interface belongs.",
+          "maxLength": 253,
+          "minLength": 1,
+          "type": "string"
+        },
+        "subnetRef": {
+          "description": "subnetRef references the subnet the router interface is created on.",
+          "maxLength": 253,
+          "minLength": 1,
+          "type": "string"
+        },
+        "type": {
+          "description": "type specifies the type of the router interface.",
+          "enum": [
+            "Subnet"
+          ],
+          "maxLength": 8,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "routerRef",
+        "type"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "subnetRef is required when type is 'Subnet' and not permitted otherwise",
+          "rule": "self.type == 'Subnet' ? has(self.subnetRef) : !has(self.subnetRef)"
+        },
+        {
+          "message": "RouterInterfaceResourceSpec is immutable",
+          "rule": "self == oldSelf"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the port created for the router interface",
+          "maxLength": 1024,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/securitygroup_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/securitygroup_v1alpha1.json
@@ -1,0 +1,539 @@
+{
+  "description": "SecurityGroup is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "notTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "notTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "projectRef": {
+                  "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "tagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "projectRef": {
+              "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "projectRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "rules": {
+              "description": "rules is a list of security group rules belonging to this SG.",
+              "items": {
+                "description": "SecurityGroupRule defines a Security Group rule",
+                "minProperties": 1,
+                "properties": {
+                  "description": {
+                    "description": "description is a human-readable description for the resource.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "direction": {
+                    "description": "direction represents the direction in which the security group rule\nis applied. Can be ingress or egress.",
+                    "enum": [
+                      "ingress",
+                      "egress"
+                    ],
+                    "type": "string"
+                  },
+                  "ethertype": {
+                    "description": "ethertype must be IPv4 or IPv6, and addresses represented in CIDR\nmust match the ingress or egress rules.",
+                    "enum": [
+                      "IPv4",
+                      "IPv6"
+                    ],
+                    "type": "string"
+                  },
+                  "portRange": {
+                    "description": "portRange sets the minimum and maximum ports range that the security group rule\nmatches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than\nor equal to the PortRange.Max attribute value.\nIf the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max\nshould be an ICMP type",
+                    "properties": {
+                      "max": {
+                        "description": "max is the maximum port number in the range that is matched by the security group rule.\nIf the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal\nto the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.",
+                        "format": "int32",
+                        "maximum": 65535,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "min": {
+                        "description": "min is the minimum port number in the range that is matched by the security group rule.\nIf the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal\nto the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type",
+                        "format": "int32",
+                        "maximum": 65535,
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "max",
+                      "min"
+                    ],
+                    "type": "object"
+                  },
+                  "protocol": {
+                    "description": "protocol is the IP protocol is represented by a string",
+                    "enum": [
+                      "ah",
+                      "dccp",
+                      "egp",
+                      "esp",
+                      "gre",
+                      "icmp",
+                      "icmpv6",
+                      "igmp",
+                      "ipip",
+                      "ipv6-encap",
+                      "ipv6-frag",
+                      "ipv6-icmp",
+                      "ipv6-nonxt",
+                      "ipv6-opts",
+                      "ipv6-route",
+                      "ospf",
+                      "pgm",
+                      "rsvp",
+                      "sctp",
+                      "tcp",
+                      "udp",
+                      "udplite",
+                      "vrrp"
+                    ],
+                    "type": "string"
+                  },
+                  "remoteIPPrefix": {
+                    "description": "remoteIPPrefix is an IP address block. Should match the Ethertype (IPv4 or IPv6)",
+                    "format": "cidr",
+                    "maxLength": 49,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "ethertype"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "portRangeMax should be equal or greater than portRange.min",
+                    "rule": "(!has(self.portRange)|| !(self.protocol == 'tcp'|| self.protocol == 'udp' || self.protocol == 'dccp' || self.protocol == 'sctp' || self.protocol == 'udplite') || (self.portRange.min <= self.portRange.max))"
+                  },
+                  {
+                    "message": "When protocol is ICMP or ICMPv6 portRange.min should be between 0 and 255",
+                    "rule": "!(self.protocol == 'icmp' || self.protocol == 'icmpv6') || !has(self.portRange)|| (self.portRange.min >= 0 && self.portRange.min <= 255)"
+                  },
+                  {
+                    "message": "When protocol is ICMP or ICMPv6 portRange.max should be between 0 and 255",
+                    "rule": "!(self.protocol == 'icmp' || self.protocol == 'icmpv6') || !has(self.portRange)|| (self.portRange.max >= 0 && self.portRange.max <= 255)"
+                  }
+                ]
+              },
+              "maxItems": 256,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "stateful": {
+              "description": "stateful indicates if the security group is stateful or stateless.",
+              "type": "boolean",
+              "x-kubernetes-validations": [
+                {
+                  "message": "stateful is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "tags": {
+              "description": "tags is a list of tags which will be applied to the security group.",
+              "items": {
+                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "createdAt": {
+              "description": "createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the security group. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "projectID": {
+              "description": "projectID is the project owner of the security group.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "revisionNumber": {
+              "description": "revisionNumber optionally set via extensions/standard-attr-revisions",
+              "format": "int64",
+              "type": "integer"
+            },
+            "rules": {
+              "description": "rules is a list of security group rules belonging to this SG.",
+              "items": {
+                "properties": {
+                  "description": {
+                    "description": "description is a human-readable description for the resource.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "direction": {
+                    "description": "direction represents the direction in which the security group rule\nis applied. Can be ingress or egress.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "ethertype": {
+                    "description": "ethertype must be IPv4 or IPv6, and addresses represented in CIDR\nmust match the ingress or egress rules.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "id": {
+                    "description": "id is the ID of the security group rule.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "portRange": {
+                    "description": "portRange sets the minimum and maximum ports range that the security group rule\nmatches. If the protocol is [tcp, udp, dccp sctp,udplite] PortRange.Min must be less than\nor equal to the PortRange.Max attribute value.\nIf the protocol is ICMP, this PortRamge.Min must be an ICMP code and PortRange.Max\nshould be an ICMP type",
+                    "properties": {
+                      "max": {
+                        "description": "max is the maximum port number in the range that is matched by the security group rule.\nIf the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be greater than or equal\nto the port_range_min attribute value. If the protocol is ICMP, this value must be an ICMP code.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "min": {
+                        "description": "min is the minimum port number in the range that is matched by the security group rule.\nIf the protocol is TCP, UDP, DCCP, SCTP or UDP-Lite this value must be less than or equal\nto the port_range_max attribute value. If the protocol is ICMP, this value must be an ICMP type",
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "protocol": {
+                    "description": "protocol is the IP protocol can be represented by a string, an\ninteger, or null",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "remoteGroupID": {
+                    "description": "remoteGroupID is the remote group UUID to associate with this security group rule\nRemoteGroupID",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "remoteIPPrefix": {
+                    "description": "remoteIPPrefix is an IP address block. Should match the Ethertype (IPv4 or IPv6)",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 256,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "stateful": {
+              "description": "stateful indicates if the security group is stateful or stateless.",
+              "type": "boolean"
+            },
+            "tags": {
+              "description": "tags is the list of tags on the resource.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "updatedAt": {
+              "description": "updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/server_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/server_v1alpha1.json
@@ -1,0 +1,587 @@
+{
+  "description": "Server is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "availabilityZone": {
+                  "description": "availabilityZone is the availability zone of the existing resource",
+                  "maxLength": 255,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "notTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "maxLength": 80,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 50,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "notTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "maxLength": 80,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 50,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "maxLength": 80,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 50,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "tagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "maxLength": 80,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 50,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "availabilityZone": {
+              "description": "availabilityZone is the availability zone in which to create the server.",
+              "maxLength": 255,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "availabilityZone is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "configDrive": {
+              "description": "configDrive specifies whether to attach a config drive to the server.\nWhen true, configuration data will be available via a special drive\ninstead of the metadata service.",
+              "type": "boolean",
+              "x-kubernetes-validations": [
+                {
+                  "message": "configDrive is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "flavorRef": {
+              "description": "flavorRef references the flavor to use for the server instance.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "flavorRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "imageRef": {
+              "description": "imageRef references the image to use for the server instance.\nNOTE: This is not required in case of boot from volume.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "imageRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "keypairRef": {
+              "description": "keypairRef is a reference to a KeyPair object. The server will be\ncreated with this keypair for SSH access.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "keypairRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "metadata": {
+              "description": "metadata is a list of metadata key-value pairs which will be set on the server.",
+              "items": {
+                "description": "ServerMetadata represents a key-value pair for server metadata.",
+                "properties": {
+                  "key": {
+                    "description": "key is the metadata key.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "value is the metadata value.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "key",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "ports": {
+              "description": "ports defines a list of ports which will be attached to the server.",
+              "items": {
+                "maxProperties": 1,
+                "minProperties": 1,
+                "properties": {
+                  "portRef": {
+                    "description": "portRef is a reference to a Port object. Server creation will wait for\nthis port to be created and available.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "serverGroupRef": {
+              "description": "serverGroupRef is a reference to a ServerGroup object. The server\nwill be created in the server group.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "serverGroupRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "tags": {
+              "description": "tags is a list of tags which will be applied to the server.",
+              "items": {
+                "maxLength": 80,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 50,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
+            "userData": {
+              "description": "userData specifies data which will be made available to the server at\nboot time, either via the metadata service or a config drive. It is\ntypically read by a configuration service such as cloud-init or ignition.",
+              "maxProperties": 1,
+              "minProperties": 1,
+              "properties": {
+                "secretRef": {
+                  "description": "secretRef is a reference to a Secret containing the user data for this server.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "userData is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "volumes": {
+              "description": "volumes is a list of volumes attached to the server.",
+              "items": {
+                "minProperties": 1,
+                "properties": {
+                  "device": {
+                    "description": "device is the name of the device, such as `/dev/vdb`.\nOmit for auto-assignment",
+                    "maxLength": 255,
+                    "type": "string"
+                  },
+                  "volumeRef": {
+                    "description": "volumeRef is a reference to a Volume object. Server creation will wait for\nthis volume to be created and available.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "volumeRef"
+                ],
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            }
+          },
+          "required": [
+            "flavorRef",
+            "imageRef",
+            "ports"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "availabilityZone": {
+              "description": "availabilityZone is the availability zone where the server is located.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "configDrive": {
+              "description": "configDrive indicates whether the server was booted with a config drive.",
+              "type": "boolean"
+            },
+            "hostID": {
+              "description": "hostID is the host where the server is located in the cloud.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "imageID": {
+              "description": "imageID indicates the OS image used to deploy the server.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "interfaces": {
+              "description": "interfaces contains the list of interfaces attached to the server.",
+              "items": {
+                "properties": {
+                  "fixedIPs": {
+                    "description": "fixedIPs is the list of fixed IP addresses assigned to the interface.",
+                    "items": {
+                      "properties": {
+                        "ipAddress": {
+                          "description": "ipAddress is the IP address assigned to the port.",
+                          "maxLength": 1024,
+                          "type": "string"
+                        },
+                        "subnetID": {
+                          "description": "subnetID is the ID of the subnet from which the IP address is allocated.",
+                          "maxLength": 1024,
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "maxItems": 32,
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "macAddr": {
+                    "description": "macAddr is the MAC address of the interface.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "netID": {
+                    "description": "netID is the ID of the network to which the interface is attached.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "portID": {
+                    "description": "portID is the ID of a port attached to the server.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "portState": {
+                    "description": "portState is the state of the port (e.g., ACTIVE, DOWN).",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "metadata": {
+              "description": "metadata is the list of metadata key-value pairs on the resource.",
+              "items": {
+                "description": "ServerMetadataStatus represents a key-value pair for server metadata in status.",
+                "properties": {
+                  "key": {
+                    "description": "key is the metadata key.",
+                    "maxLength": 255,
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "value is the metadata value.",
+                    "maxLength": 255,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 128,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "name": {
+              "description": "name is the human-readable name of the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "serverGroups": {
+              "description": "serverGroups is a slice of strings containing the UUIDs of the\nserver groups to which the server belongs. Currently this can\ncontain at most one entry.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 32,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "status": {
+              "description": "status contains the current operational status of the server,\nsuch as IN_PROGRESS or ACTIVE.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "tags": {
+              "description": "tags is the list of tags on the resource.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 50,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "volumes": {
+              "description": "volumes contains the volumes attached to the server.",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "id is the ID of a volume attached to the server.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/servergroup_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/servergroup_v1alpha1.json
@@ -1,0 +1,286 @@
+{
+  "description": "ServerGroup is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "policy": {
+              "description": "policy is the policy to use for the server group.",
+              "enum": [
+                "affinity",
+                "anti-affinity",
+                "soft-affinity",
+                "soft-anti-affinity"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "rules is the rules to use for the server group.",
+              "properties": {
+                "maxServerPerHost": {
+                  "description": "maxServerPerHost specifies how many servers can reside on a single compute host.\nIt can be used only with the \"anti-affinity\" policy.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "policy"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "ServerGroupResourceSpec is immutable",
+              "rule": "self == oldSelf"
+            },
+            {
+              "message": "maxServerPerHost can only be used with the anti-affinity policy",
+              "rule": "has(self.rules) && self.rules.maxServerPerHost > 0 ? self.policy == 'anti-affinity' : true"
+            }
+          ]
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "name": {
+              "description": "name is a Human-readable name for the servergroup. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "policy": {
+              "description": "policy is the policy of the servergroup.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "projectID": {
+              "description": "projectID is the project owner of the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "rules": {
+              "description": "rules is the rules of the server group.",
+              "properties": {
+                "maxServerPerHost": {
+                  "description": "maxServerPerHost specifies how many servers can reside on a single compute host.\nIt can be used only with the \"anti-affinity\" policy.",
+                  "format": "int32",
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "userID": {
+              "description": "userID of the server group.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/service_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/service_v1alpha1.json
@@ -1,0 +1,266 @@
+{
+  "description": "Service is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description indicates the description of service.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "enabled": {
+              "default": true,
+              "description": "enabled indicates whether the service is enabled or not.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name indicates the name of service. If not specified, the name of the ORC\nresource will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "type": {
+              "description": "type indicates which resource the service is responsible for.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "description": {
+              "description": "description indicates the description of service.",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "enabled": {
+              "description": "enabled indicates whether the service is enabled or not.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name indicates the name of service.",
+              "maxLength": 255,
+              "type": "string"
+            },
+            "type": {
+              "description": "type indicates which resource the service is responsible for.",
+              "maxLength": 255,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/subnet_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/subnet_v1alpha1.json
@@ -1,0 +1,691 @@
+{
+  "description": "Subnet is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "cidr": {
+                  "description": "cidr of the existing resource",
+                  "format": "cidr",
+                  "maxLength": 49,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "gatewayIP": {
+                  "description": "gatewayIP is the IP address of the gateway of the existing resource",
+                  "maxLength": 45,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "ipVersion": {
+                  "description": "ipVersion of the existing resource",
+                  "enum": [
+                    4,
+                    6
+                  ],
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "ipv6": {
+                  "description": "ipv6 options of the existing resource",
+                  "minProperties": 1,
+                  "properties": {
+                    "addressMode": {
+                      "description": "addressMode specifies mechanisms for assigning IPv6 IP addresses.",
+                      "enum": [
+                        "slaac",
+                        "dhcpv6-stateful",
+                        "dhcpv6-stateless"
+                      ],
+                      "type": "string"
+                    },
+                    "raMode": {
+                      "description": "raMode specifies the IPv6 router advertisement mode. It specifies whether\nthe networking service should transmit ICMPv6 packets.",
+                      "enum": [
+                        "slaac",
+                        "dhcpv6-stateful",
+                        "dhcpv6-stateless"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "networkRef": {
+                  "description": "networkRef is a reference to the ORC Network which this subnet is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "notTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "notTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "projectRef": {
+                  "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "tagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "allocationPools": {
+              "description": "allocationPools are IP Address pools that will be available for DHCP. IP\naddresses must be in CIDR.",
+              "items": {
+                "properties": {
+                  "end": {
+                    "description": "end is the last IP address in the allocation pool.",
+                    "maxLength": 45,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "start": {
+                    "description": "start is the first IP address in the allocation pool.",
+                    "maxLength": 45,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "end",
+                  "start"
+                ],
+                "type": "object"
+              },
+              "maxItems": 32,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "cidr": {
+              "description": "cidr is the address CIDR of the subnet. It must match the IP version specified in IPVersion.",
+              "format": "cidr",
+              "maxLength": 49,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "cidr is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "dnsNameservers": {
+              "description": "dnsNameservers are the nameservers to be set via DHCP.",
+              "items": {
+                "maxLength": 45,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 16,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            },
+            "dnsPublishFixedIP": {
+              "description": "dnsPublishFixedIP will either enable or disable the publication of\nfixed IPs to the DNS. Defaults to false.",
+              "type": "boolean",
+              "x-kubernetes-validations": [
+                {
+                  "message": "dnsPublishFixedIP is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "enableDHCP": {
+              "description": "enableDHCP will either enable to disable the DHCP service.",
+              "type": "boolean"
+            },
+            "gateway": {
+              "description": "gateway specifies the default gateway of the subnet. If not specified,\nneutron will add one automatically. To disable this behaviour, specify a\ngateway with a type of None.",
+              "properties": {
+                "ip": {
+                  "description": "ip is the IP address of the default gateway, which must be specified if\nType is `IP`. It must be a valid IP address, either IPv4 or IPv6,\nmatching the IPVersion in SubnetResourceSpec.",
+                  "maxLength": 45,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type specifies how the default gateway will be created. `Automatic`\nspecifies that neutron will automatically add a default gateway. This is\nalso the default if no Gateway is specified. `None` specifies that the\nsubnet will not have a default gateway. `IP` specifies that the subnet\nwill use a specific address as the default gateway, which must be\nspecified in `IP`.",
+                  "enum": [
+                    "None",
+                    "Automatic",
+                    "IP"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            "hostRoutes": {
+              "description": "hostRoutes are any static host routes to be set via DHCP.",
+              "items": {
+                "properties": {
+                  "destination": {
+                    "description": "destination for the additional route.",
+                    "format": "cidr",
+                    "maxLength": 49,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "nextHop": {
+                    "description": "nextHop for the additional route.",
+                    "maxLength": 45,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "destination",
+                  "nextHop"
+                ],
+                "type": "object"
+              },
+              "maxItems": 256,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "ipVersion": {
+              "description": "ipVersion is the IP version for the subnet.",
+              "enum": [
+                4,
+                6
+              ],
+              "format": "int32",
+              "type": "integer",
+              "x-kubernetes-validations": [
+                {
+                  "message": "ipVersion is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "ipv6": {
+              "description": "ipv6 contains IPv6-specific options. It may only be set if IPVersion is 6.",
+              "minProperties": 1,
+              "properties": {
+                "addressMode": {
+                  "description": "addressMode specifies mechanisms for assigning IPv6 IP addresses.",
+                  "enum": [
+                    "slaac",
+                    "dhcpv6-stateful",
+                    "dhcpv6-stateless"
+                  ],
+                  "type": "string"
+                },
+                "raMode": {
+                  "description": "raMode specifies the IPv6 router advertisement mode. It specifies whether\nthe networking service should transmit ICMPv6 packets.",
+                  "enum": [
+                    "slaac",
+                    "dhcpv6-stateful",
+                    "dhcpv6-stateless"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "ipv6 is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "name": {
+              "description": "name is a human-readable name of the subnet. If not set, the object's name will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "networkRef": {
+              "description": "networkRef is a reference to the ORC Network which this subnet is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "networkRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "projectRef": {
+              "description": "projectRef is a reference to the ORC Project this resource is associated with.\nTypically, only used by admin.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "projectRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "routerRef": {
+              "description": "routerRef specifies a router to attach the subnet to",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "routerRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "tags": {
+              "description": "tags is a list of tags which will be applied to the subnet.",
+              "items": {
+                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            }
+          },
+          "required": [
+            "cidr",
+            "ipVersion",
+            "networkRef"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "allocationPools": {
+              "description": "allocationPools is a list of sub-ranges within CIDR available for dynamic\nallocation to ports.",
+              "items": {
+                "properties": {
+                  "end": {
+                    "description": "end is the last IP address in the allocation pool.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "start": {
+                    "description": "start is the first IP address in the allocation pool.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 32,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "cidr": {
+              "description": "cidr representing IP range for this subnet, based on IP version.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "createdAt": {
+              "description": "createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "dnsNameservers": {
+              "description": "dnsNameservers is a list of name servers used by hosts in this subnet.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 16,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "dnsPublishFixedIP": {
+              "description": "dnsPublishFixedIP specifies whether the fixed IP addresses are published to the DNS.",
+              "type": "boolean"
+            },
+            "enableDHCP": {
+              "description": "enableDHCP specifies whether DHCP is enabled for this subnet or not.",
+              "type": "boolean"
+            },
+            "gatewayIP": {
+              "description": "gatewayIP is the default gateway used by devices in this subnet, if any.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "hostRoutes": {
+              "description": "hostRoutes is a list of routes that should be used by devices with IPs\nfrom this subnet (not including local subnet route).",
+              "items": {
+                "properties": {
+                  "destination": {
+                    "description": "destination for the additional route.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "nextHop": {
+                    "description": "nextHop for the additional route.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 256,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "ipVersion": {
+              "description": "ipVersion specifies IP version, either `4' or `6'.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "ipv6AddressMode": {
+              "description": "ipv6AddressMode specifies mechanisms for assigning IPv6 IP addresses.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "ipv6RAMode": {
+              "description": "ipv6RAMode is the IPv6 router advertisement mode. It specifies\nwhether the networking service should transmit ICMPv6 packets.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "name": {
+              "description": "name is the human-readable name of the subnet. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "networkID": {
+              "description": "networkID is the ID of the network to which the subnet belongs.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "projectID": {
+              "description": "projectID is the project owner of the subnet.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "revisionNumber": {
+              "description": "revisionNumber optionally set via extensions/standard-attr-revisions",
+              "format": "int64",
+              "type": "integer"
+            },
+            "subnetPoolID": {
+              "description": "subnetPoolID is the id of the subnet pool associated with the subnet.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "tags": {
+              "description": "tags optionally set via extensions/attributestags",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "updatedAt": {
+              "description": "updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/trunk_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/trunk_v1alpha1.json
@@ -1,0 +1,466 @@
+{
+  "description": "Trunk is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "adminStateUp": {
+                  "description": "adminStateUp is the administrative state of the trunk.",
+                  "type": "boolean"
+                },
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "notTags": {
+                  "description": "notTags is a list of tags to filter by. If specified, resources which\ncontain all of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "notTagsAny": {
+                  "description": "notTagsAny is a list of tags to filter by. If specified, resources\nwhich contain any of the given tags will be excluded from the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "portRef": {
+                  "description": "portRef is a reference to the ORC Port which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "projectRef": {
+                  "description": "projectRef is a reference to the ORC Project which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tags": {
+                  "description": "tags is a list of tags to filter by. If specified, the resource must\nhave all of the tags specified to be included in the result.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "tagsAny": {
+                  "description": "tagsAny is a list of tags to filter by. If specified, the resource\nmust have at least one of the tags specified to be included in the\nresult.",
+                  "items": {
+                    "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "adminStateUp": {
+              "description": "adminStateUp is the administrative state of the trunk. If false (down),\nthe trunk does not forward packets.",
+              "type": "boolean"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "portRef": {
+              "description": "portRef is a reference to the ORC Port which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "portRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "projectRef": {
+              "description": "projectRef is a reference to the ORC Project which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "projectRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "subports": {
+              "description": "subports is the list of ports to attach to the trunk.",
+              "items": {
+                "description": "TrunkSubportSpec represents a subport to attach to a trunk.\nIt maps to gophercloud's trunks.Subport.",
+                "properties": {
+                  "portRef": {
+                    "description": "portRef is a reference to the ORC Port that will be attached as a subport.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "segmentationID": {
+                    "description": "segmentationID is the segmentation ID for the subport (e.g. VLAN ID).",
+                    "format": "int32",
+                    "maximum": 4094,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "segmentationType": {
+                    "description": "segmentationType is the segmentation type for the subport (e.g. vlan).",
+                    "enum": [
+                      "inherit",
+                      "vlan"
+                    ],
+                    "maxLength": 32,
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "portRef",
+                  "segmentationID",
+                  "segmentationType"
+                ],
+                "type": "object"
+              },
+              "maxItems": 1024,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "tags": {
+              "description": "tags is a list of Neutron tags to apply to the trunk.",
+              "items": {
+                "description": "NeutronTag represents a tag on a Neutron resource.\nIt may not be empty and may not contain commas.",
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "set"
+            }
+          },
+          "required": [
+            "portRef"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "adminStateUp": {
+              "description": "adminStateUp is the administrative state of the trunk.",
+              "type": "boolean"
+            },
+            "createdAt": {
+              "description": "createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "portID": {
+              "description": "portID is the ID of the Port to which the resource is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "projectID": {
+              "description": "projectID is the ID of the Project to which the resource is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "revisionNumber": {
+              "description": "revisionNumber optionally set via extensions/standard-attr-revisions",
+              "format": "int64",
+              "type": "integer"
+            },
+            "status": {
+              "description": "status indicates whether the trunk is currently operational.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "subports": {
+              "description": "subports is a list of ports associated with the trunk.",
+              "items": {
+                "description": "TrunkSubportStatus represents an attached subport on a trunk.\nIt maps to gophercloud's trunks.Subport.",
+                "properties": {
+                  "portID": {
+                    "description": "portID is the OpenStack ID of the Port attached as a subport.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "segmentationID": {
+                    "description": "segmentationID is the segmentation ID for the subport (e.g. VLAN ID).",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "segmentationType": {
+                    "description": "segmentationType is the segmentation type for the subport (e.g. vlan).",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 1024,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "tags": {
+              "description": "tags is the list of tags on the resource.",
+              "items": {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "tenantID": {
+              "description": "tenantID is the project owner of the trunk (alias of projectID in some deployments).",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "updatedAt": {
+              "description": "updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/user_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/user_v1alpha1.json
@@ -1,0 +1,307 @@
+{
+  "description": "User is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "domainRef": {
+                  "description": "domainRef is a reference to the ORC Domain which this resource is associated with.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "defaultProjectRef": {
+              "description": "defaultProjectRef is a reference to the Default Project which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "defaultProjectRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "domainRef": {
+              "description": "domainRef is a reference to the ORC Domain which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "domainRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "enabled": {
+              "description": "enabled defines whether a user is enabled or disabled",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "passwordRef": {
+              "description": "passwordRef is a reference to a Secret containing the password\nfor this user. The Secret must contain a key named \"password\".\nIf not specified, the user is created without a password.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "passwordRef may not be removed once set",
+              "rule": "!has(oldSelf.passwordRef) || has(self.passwordRef)"
+            }
+          ]
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "appliedPasswordRef": {
+              "description": "appliedPasswordRef is the name of the Secret containing the\npassword that was last applied to the OpenStack resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "defaultProjectID": {
+              "description": "defaultProjectID is the ID of the Default Project to which the user is associated with.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "domainID": {
+              "description": "domainID is the ID of the Domain to which the resource is associated.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "enabled": {
+              "description": "enabled defines whether a user is enabled or disabled",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "passwordExpiresAt": {
+              "description": "passwordExpiresAt is the timestamp at which the user's password expires.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/volume_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/volume_v1alpha1.json
@@ -1,0 +1,474 @@
+{
+  "description": "Volume is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "availabilityZone": {
+                  "description": "availabilityZone is the availability zone of the existing resource",
+                  "maxLength": 255,
+                  "type": "string"
+                },
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                },
+                "size": {
+                  "description": "size is the size of the volume in GiB.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "availabilityZone": {
+              "description": "availabilityZone is the availability zone in which to create the volume.",
+              "maxLength": 255,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "availabilityZone is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "imageRef": {
+              "description": "imageRef is a reference to an ORC Image. If specified, creates a\nbootable volume from this image. The volume size must be >= the\nimage's min_disk requirement.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "imageRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "metadata": {
+              "description": "metadata key and value pairs to be associated with the volume.\nNOTE(mandre): gophercloud can't clear all metadata at the moment, we thus can't allow\nmutability for metadata as we might end up in a state that is not reconciliable",
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "name is the name of the metadata",
+                    "maxLength": 255,
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "value is the value of the metadata",
+                    "maxLength": 255,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic",
+              "x-kubernetes-validations": [
+                {
+                  "message": "metadata is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            },
+            "size": {
+              "description": "size is the size of the volume, in gibibytes (GiB).",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer",
+              "x-kubernetes-validations": [
+                {
+                  "message": "size is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            },
+            "volumeTypeRef": {
+              "description": "volumeTypeRef is a reference to the ORC VolumeType which this resource is associated with.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "volumeTypeRef is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
+            }
+          },
+          "required": [
+            "size"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "attachments": {
+              "description": "attachments is a list of attachments for the volume.",
+              "items": {
+                "properties": {
+                  "attachedAt": {
+                    "description": "attachedAt shows the date and time when the resource was attached. The date and time stamp format is ISO 8601.",
+                    "format": "date-time",
+                    "type": "string"
+                  },
+                  "attachmentID": {
+                    "description": "attachmentID represents the attachment UUID.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "device": {
+                    "description": "device is the name of the device in the instance.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  },
+                  "serverID": {
+                    "description": "serverID is the UUID of the server to which the volume is attached.",
+                    "maxLength": 1024,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 32,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "availabilityZone": {
+              "description": "availabilityZone is which availability zone the volume is in.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "backupID": {
+              "description": "backupID is the ID of the backup from which the volume was restored",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "bootable": {
+              "description": "bootable indicates whether this is a bootable volume.",
+              "type": "boolean"
+            },
+            "consistencyGroupID": {
+              "description": "consistencyGroupID is the consistency group ID.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "createdAt": {
+              "description": "createdAt shows the date and time when the resource was created. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            },
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "encrypted": {
+              "description": "encrypted denotes if the volume is encrypted.",
+              "type": "boolean"
+            },
+            "host": {
+              "description": "host is the identifier of the host holding the volume.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "imageID": {
+              "description": "imageID is the ID of the image this volume was created from, if any.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "metadata": {
+              "description": "metadata key and value pairs to be associated with the volume.",
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "name is the name of the metadata",
+                    "maxLength": 255,
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "value is the value of the metadata",
+                    "maxLength": 255,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "multiattach": {
+              "description": "multiattach denotes if the volume is multi-attach capable.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "replicationStatus": {
+              "description": "replicationStatus is the status of replication.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "size": {
+              "description": "size is the size of the volume in GiB.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "snapshotID": {
+              "description": "snapshotID is the ID of the snapshot from which the volume was created",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "sourceVolID": {
+              "description": "sourceVolID is the ID of another block storage volume from which the current volume was created",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "status": {
+              "description": "status represents the current status of the volume.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "tenantID": {
+              "description": "tenantID is the ID of the project that owns the volume.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "updatedAt": {
+              "description": "updatedAt shows the date and time when the resource was updated. The date and time stamp format is ISO 8601",
+              "format": "date-time",
+              "type": "string"
+            },
+            "userID": {
+              "description": "userID is the ID of the user who created the volume.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "volumeType": {
+              "description": "volumeType is the name of associated the volume type.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/openstack.k-orc.cloud/volumetype_v1alpha1.json
+++ b/schemas/openstack.k-orc.cloud/volumetype_v1alpha1.json
@@ -1,0 +1,301 @@
+{
+  "description": "VolumeType is the Schema for an ORC resource.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec specifies the desired state of the resource.",
+      "properties": {
+        "cloudCredentialsRef": {
+          "description": "cloudCredentialsRef points to a secret containing OpenStack credentials",
+          "properties": {
+            "cloudName": {
+              "description": "cloudName specifies the name of the entry in the clouds.yaml file to use.",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "secretName": {
+              "description": "secretName is the name of a secret in the same namespace as the resource being provisioned.\nThe secret must contain a key named `clouds.yaml` which contains an OpenStack clouds.yaml file.\nThe secret may optionally contain a key named `cacert` containing a PEM-encoded CA certificate.",
+              "maxLength": 253,
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "required": [
+            "cloudName",
+            "secretName"
+          ],
+          "type": "object"
+        },
+        "import": {
+          "description": "import refers to an existing OpenStack resource which will be imported instead of\ncreating a new one.",
+          "maxProperties": 1,
+          "minProperties": 1,
+          "properties": {
+            "filter": {
+              "description": "filter contains a resource query which is expected to return a single\nresult. The controller will continue to retry if filter returns no\nresults. If filter returns multiple results the controller will set an\nerror state and will not continue to retry.",
+              "minProperties": 1,
+              "properties": {
+                "description": {
+                  "description": "description of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "isPublic": {
+                  "description": "isPublic indicates whether the VolumeType is public.",
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "name of the existing resource",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "pattern": "^[^,]+$",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "description": "id contains the unique identifier of an existing OpenStack resource. Note\nthat when specifying an import by ID, the resource MUST already exist.\nThe ORC object will enter an error state if the resource does not exist.",
+              "format": "uuid",
+              "maxLength": 36,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managedOptions": {
+          "description": "managedOptions specifies options which may be applied to managed objects.",
+          "properties": {
+            "onDelete": {
+              "default": "delete",
+              "description": "onDelete specifies the behaviour of the controller when the ORC\nobject is deleted. Options are `delete` - delete the OpenStack resource;\n`detach` - do not delete the OpenStack resource. If not specified, the\ndefault is `delete`.",
+              "enum": [
+                "delete",
+                "detach"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "managementPolicy": {
+          "default": "managed",
+          "description": "managementPolicy defines how ORC will treat the object. Valid values are\n`managed`: ORC will create, update, and delete the resource; `unmanaged`:\nORC will import an existing resource, and will not apply updates to it or\ndelete it.",
+          "enum": [
+            "managed",
+            "unmanaged"
+          ],
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "managementPolicy is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "resource": {
+          "description": "resource specifies the desired state of the resource.\n\nresource may not be specified if the management policy is `unmanaged`.\n\nresource must be specified if the management policy is `managed`.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 255,
+              "minLength": 1,
+              "type": "string"
+            },
+            "extraSpecs": {
+              "description": "extraSpecs is a map of key-value pairs that define extra specifications for the volume type.",
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "name is the name of the extraspec",
+                    "maxLength": 255,
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "value is the value of the extraspec",
+                    "maxLength": 255,
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "isPublic": {
+              "description": "isPublic indicates whether the volume type is public.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name will be the name of the created resource. If not specified, the\nname of the ORC object will be used.",
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[^,]+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "cloudCredentialsRef"
+      ],
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "resource must be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? has(self.resource) : true"
+        },
+        {
+          "message": "import may not be specified when policy is managed",
+          "rule": "self.managementPolicy == 'managed' ? !has(self.__import__) : true"
+        },
+        {
+          "message": "resource may not be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? !has(self.resource) : true"
+        },
+        {
+          "message": "import must be specified when policy is unmanaged",
+          "rule": "self.managementPolicy == 'unmanaged' ? has(self.__import__) : true"
+        },
+        {
+          "message": "managedOptions may only be provided when policy is managed",
+          "rule": "has(self.managedOptions) ? self.managementPolicy == 'managed' : true"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the observed state of the resource.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the observed status of the object.\nKnown .status.conditions.type are: \"Available\", \"Progressing\"\n\nAvailable represents the availability of the OpenStack resource. If it is\ntrue then the resource is ready for use.\n\nProgressing indicates whether the controller is still attempting to\nreconcile the current state of the OpenStack resource to the desired\nstate. Progressing will be False either because the desired state has\nbeen achieved, or because some terminal error prevents it from ever being\nachieved and the controller is no longer attempting to reconcile. If\nProgressing is True, an observer waiting on the resource should continue\nto wait.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 32,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "id": {
+          "description": "id is the unique identifier of the OpenStack resource.",
+          "maxLength": 1024,
+          "type": "string"
+        },
+        "resource": {
+          "description": "resource contains the observed state of the OpenStack resource.",
+          "properties": {
+            "description": {
+              "description": "description is a human-readable description for the resource.",
+              "maxLength": 1024,
+              "type": "string"
+            },
+            "extraSpecs": {
+              "description": "extraSpecs is a map of key-value pairs that define extra specifications for the volume type.",
+              "items": {
+                "properties": {
+                  "name": {
+                    "description": "name is the name of the extraspec",
+                    "maxLength": 255,
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "value is the value of the extraspec",
+                    "maxLength": 255,
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "maxItems": 64,
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "isPublic": {
+              "description": "isPublic indicates whether the VolumeType is public.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "name is a Human-readable name for the resource. Might not be unique.",
+              "maxLength": 1024,
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

- Adds `crds/k-orc.sh` download script for the OpenStack Resource Controller (ORC) operator pinned at v2.5.0 with Renovate tracking
- Generates JSON schemas under `openstack.k-orc.cloud` covering compute (servers, flavors, keypairs, server groups), networking (networks, subnets, routers, ports, floating IPs, security groups, trunks, address scopes), identity (users, projects, domains, groups, roles, application credentials), and storage (volumes, volume types)
- Updates `public/data/catalog.json` with all new ORC resource entries

Closes: #288