### PR TITLE
feat(website): implement agent-ready website improvements

### DIFF
--- a/.claude/skills/openspec-hub-schema-lookup.md
+++ b/.claude/skills/openspec-hub-schema-lookup.md
@@ -1,0 +1,24 @@
+---
+description: Look up Kubernetes CRD JSON schemas from OpenSpec HUB. Use when the user needs a $schema URL for a Kubernetes resource, wants to validate manifests, or asks about CRD schemas for operators like cert-manager, ArgoCD, Flux, External Secrets, Prometheus, etc.
+---
+
+Fetch the catalog and resolve the schema URL for the requested resource.
+
+## Steps
+
+1. Fetch https://openspec-hub.portefaix.xyz/data/catalog.json
+2. Search `catalog.groups` — keys are API group names (e.g. `cert-manager.io`), values are arrays of `{ kind, version, file, slug }` objects
+3. Match on `kind` (case-insensitive) and optionally `group`
+4. Build the raw schema URL: `https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{file}`
+5. Return the URL and offer the yaml-language-server snippet:
+   `# yaml-language-server: $schema=<url>`
+
+## Multiple versions
+
+If multiple versions exist for the same kind, list all and suggest the highest stable version (prefer `v1` > `v1beta1` > `v1alpha1`).
+
+## If not found
+
+Tell the user the kind was not found in the catalog and link them to:
+https://openspec-hub.portefaix.xyz
+so they can search manually or open an issue to request the schema.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,12 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
 import tailwindcss from '@tailwindcss/vite';
+import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
+  site: 'https://openspec-hub.portefaix.xyz',
   output: 'static',
-  integrations: [react()],
+  integrations: [react(), sitemap()],
   vite: {
     plugins: [tailwindcss()],
   },

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "openspec-hub-web",
       "dependencies": {
         "@astrojs/react": "^5.0.2",
+        "@astrojs/sitemap": "^3.7.2",
         "astro": "6.1.6",
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
@@ -27,6 +28,8 @@
     "@astrojs/prism": ["@astrojs/prism@4.0.1", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ=="],
 
     "@astrojs/react": ["@astrojs/react@5.0.2", "", { "dependencies": { "@astrojs/internal-helpers": "0.8.0", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.6.4", "ultrahtml": "^1.6.0", "vite": "^7.3.1" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-BDpPrapV3Wgp9sD7aTMvP+ORH0jFEue9OmkBu98KcBbTlsQCnvisDW3m7PQrMptXwEDlX5HGfP/CHmkEVY2tZA=="],
+
+    "@astrojs/sitemap": ["@astrojs/sitemap@3.7.2", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.0", "", { "dependencies": { "ci-info": "^4.2.0", "debug": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^3.0.0", "is-wsl": "^3.1.0", "which-pm-runs": "^1.1.0" } }, "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ=="],
 
@@ -310,9 +313,13 @@
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
+    "@types/node": ["@types/node@24.12.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA=="],
+
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -321,6 +328,8 @@
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -724,11 +733,15 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
+
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -761,6 +774,8 @@
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,0 +1,45 @@
+/**
+ * Cloudflare Pages Function middleware for Accept: text/markdown content negotiation.
+ * Serves pre-generated .md endpoints when agents request markdown.
+ * Ref: https://isitagentready.com/.well-known/agent-skills/markdown-negotiation/SKILL.md
+ */
+
+export async function onRequest({ request, next }) {
+    const accept = request.headers.get('Accept') ?? '';
+    const wantsMarkdown = accept.includes('text/markdown') || accept.includes('text/*');
+
+    if (wantsMarkdown) {
+        const url = new URL(request.url);
+        const mdPath = url.pathname === '/' ? '/index.md' : `${url.pathname.replace(/\/$/, '')}.md`;
+        const mdUrl = new URL(mdPath, url.origin).toString();
+
+        try {
+            const mdRes = await fetch(mdUrl);
+            if (mdRes.ok) {
+                const body = await mdRes.text();
+                return new Response(body, {
+                    status: 200,
+                    headers: {
+                        'Content-Type': 'text/markdown; charset=utf-8',
+                        'Vary': 'Accept',
+                        'x-markdown-tokens': String(Math.ceil(body.length / 4)),
+                        'Cache-Control': 'public, max-age=3600',
+                    },
+                });
+            }
+        } catch {
+            // No .md variant available — fall through to normal HTML response
+        }
+    }
+
+    const response = await next();
+
+    // Always advertise that Accept negotiation is supported
+    const newHeaders = new Headers(response.headers);
+    newHeaders.set('Vary', 'Accept');
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: newHeaders,
+    });
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^5.0.2",
+    "@astrojs/sitemap": "^3.7.2",
     "astro": "6.1.6",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",

--- a/public/.well-known/agent-skills/schema-lookup/SKILL.md
+++ b/public/.well-known/agent-skills/schema-lookup/SKILL.md
@@ -1,0 +1,49 @@
+# OpenSpec HUB: Schema Lookup
+
+Retrieve a Kubernetes CRD JSON schema by kind, API group, and version from the OpenSpec HUB registry.
+
+## Catalog endpoint
+
+GET https://openspec-hub.portefaix.xyz/data/catalog.json
+
+The response is a JSON object with a `groups` key that maps API group names to arrays of resources:
+
+```json
+{
+  "groups": {
+    "cert-manager.io": [
+      {
+        "kind": "Certificate",
+        "version": "v1",
+        "file": "cert-manager.io/certificate_v1.json",
+        "slug": "cert-manager.io/v1/certificate"
+      }
+    ]
+  }
+}
+```
+
+## Lookup steps
+
+1. Fetch `catalog.json`
+2. Search `groups` for entries where `kind` (case-insensitive) and/or group name match the query
+3. Build the raw schema URL from the `file` field:
+
+```
+https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{file}
+```
+
+## Direct URL pattern
+
+```
+https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{api-group}/{kind}_{version}.json
+```
+
+Example:
+```
+https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/cert-manager.io/certificate_v1.json
+```
+
+## Browse
+
+Human-readable schema pages: https://openspec-hub.portefaix.xyz/schemas/{slug}

--- a/public/.well-known/agent-skills/schema-validate/SKILL.md
+++ b/public/.well-known/agent-skills/schema-validate/SKILL.md
@@ -1,0 +1,40 @@
+# OpenSpec HUB: Schema Validation
+
+Validate Kubernetes manifests against CRD JSON schemas sourced from OpenSpec HUB.
+
+## Schema URL pattern
+
+```
+https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{api-group}/{kind}_{version}.json
+```
+
+## kubeconform
+
+```bash
+kubeconform \
+  -schema-location 'https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{{ .Group }}/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json' \
+  manifest.yaml
+```
+
+## yaml-language-server (VS Code / neovim)
+
+Add this comment to the top of any Kubernetes YAML manifest:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{api-group}/{kind}_{version}.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+```
+
+## JSON Schema $schema field
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/cert-manager.io/certificate_v1.json"
+}
+```
+
+## Finding the right URL
+
+Use the schema-lookup skill or fetch the catalog directly:
+GET https://openspec-hub.portefaix.xyz/data/catalog.json

--- a/public/.well-known/api-catalog.json
+++ b/public/.well-known/api-catalog.json
@@ -1,0 +1,25 @@
+{
+  "apis": [
+    {
+      "title": "OpenSpec HUB Schema Catalog",
+      "description": "Machine-readable index of Kubernetes CRD JSON schemas across 294+ API groups and 70+ operators.",
+      "links": [
+        {
+          "href": "https://openspec-hub.portefaix.xyz/data/catalog.json",
+          "rel": "describedby",
+          "type": "application/json"
+        },
+        {
+          "href": "https://openspec-hub.portefaix.xyz/sitemap.xml",
+          "rel": "sitemap",
+          "type": "application/xml"
+        },
+        {
+          "href": "https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/",
+          "rel": "service-desc",
+          "type": "application/json"
+        }
+      ]
+    }
+  ]
+}

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,7 @@
+# Cloudflare Pages / Netlify response headers
+# GitHub Pages does not support custom response headers;
+# use Cloudflare Transform Rules or a Worker for that host.
+
+/
+  Link: </.well-known/api-catalog.json>; rel="api-catalog", </data/catalog.json>; rel="describedby", <https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/>; rel="service-desc", </index.md>; rel="alternate"; type="text/markdown"
+  Vary: Accept

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,49 @@
+User-agent: *
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+# OpenAI
+User-agent: GPTBot
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+User-agent: OAI-SearchBot
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+# Anthropic
+User-agent: Claude-Web
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+User-agent: anthropic-ai
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+# Google
+User-agent: Google-Extended
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+# Amazon
+User-agent: Amazonbot
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+# Apple
+User-agent: Applebot-Extended
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+# ByteDance / TikTok
+User-agent: Bytespider
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+# Common Crawl
+User-agent: CCBot
+Allow: /
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+
+Sitemap: https://openspec-hub.portefaix.xyz/sitemap.xml
+Sitemap: https://openspec-hub.portefaix.xyz/sitemap-index.xml

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,16 +26,20 @@ const currentPath = Astro.url.pathname;
 		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
 		<meta name="generator" content={Astro.generator} />
 		<title>{title} | OpenSpec HUB</title>
+		<link rel="canonical" href={Astro.url.href} />
 		<!-- Open Graph -->
 		<meta property="og:title" content={`${title} | OpenSpec HUB`} />
 		<meta property="og:description" content={description} />
 		<meta property="og:type" content="website" />
 		<meta property="og:site_name" content="OpenSpec HUB" />
+		<meta property="og:url" content={Astro.url.href} />
 		<meta property="og:image" content="/og.svg" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content={`${title} | OpenSpec HUB`} />
 		<meta name="twitter:description" content={description} />
 		<meta name="twitter:image" content="/og.svg" />
+		<!-- Page-specific head tags (e.g. discovery link relations) -->
+		<slot name="head" />
 		<!-- Dark mode: apply before paint to avoid flash -->
 		<script is:inline>
 			const t = localStorage.getItem('theme') || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');

--- a/src/pages/.well-known/agent-skills/index.json.ts
+++ b/src/pages/.well-known/agent-skills/index.json.ts
@@ -1,0 +1,46 @@
+import type { APIRoute } from 'astro';
+import * as fs from 'node:fs';
+import * as crypto from 'node:crypto';
+import * as path from 'node:path';
+
+const SITE = 'https://openspec-hub.portefaix.xyz';
+const SKILLS_DIR = path.resolve('public/.well-known/agent-skills');
+
+function sha256Digest(filePath: string): string {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    return 'sha256:' + crypto.createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+const SKILLS = [
+    {
+        name: 'schema-lookup',
+        type: 'skill-md' as const,
+        description: 'Look up a Kubernetes CRD JSON schema by kind, API group, and version from the OpenSpec HUB registry.',
+        skillFile: path.join(SKILLS_DIR, 'schema-lookup', 'SKILL.md'),
+        url: `${SITE}/.well-known/agent-skills/schema-lookup/SKILL.md`,
+    },
+    {
+        name: 'schema-validate',
+        type: 'skill-md' as const,
+        description: 'Validate Kubernetes manifests against CRD schemas using kubeconform or yaml-language-server.',
+        skillFile: path.join(SKILLS_DIR, 'schema-validate', 'SKILL.md'),
+        url: `${SITE}/.well-known/agent-skills/schema-validate/SKILL.md`,
+    },
+];
+
+export const GET: APIRoute = () => {
+    const index = {
+        $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+        skills: SKILLS.map(s => ({
+            name: s.name,
+            type: s.type,
+            description: s.description,
+            url: s.url,
+            digest: sha256Digest(s.skillFile),
+        })),
+    };
+
+    return new Response(JSON.stringify(index, null, 2), {
+        headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
+};

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,27 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="404 – Not Found" description="This schema or page could not be found.">
+  <div class="max-w-2xl mx-auto px-6 py-32 text-center">
+    <div class="text-8xl font-black text-gray-100 dark:text-slate-800 mb-6 leading-none select-none">404</div>
+    <h1 class="text-2xl font-extrabold text-gray-900 dark:text-white mb-3 tracking-tight">Page not found</h1>
+    <p class="text-sm text-gray-500 dark:text-slate-400 mb-10 leading-relaxed">
+      The schema or page you're looking for doesn't exist, or may have been moved.
+    </p>
+    <div class="flex flex-col sm:flex-row justify-center gap-3">
+      <a
+        href="/"
+        class="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-xl transition-colors shadow-sm"
+      >
+        Browse all schemas
+      </a>
+      <a
+        href="https://github.com/nlamirault/openspec-hub/issues"
+        class="px-5 py-2.5 border border-gray-200 dark:border-slate-700 text-gray-700 dark:text-slate-300 hover:border-blue-300 dark:hover:border-blue-600 text-sm font-semibold rounded-xl transition-colors"
+      >
+        Report a missing schema
+      </a>
+    </div>
+  </div>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -189,6 +189,14 @@ const filterData = groupedData.map(cat => ({
 ---
 
 <Layout title="Home">
+  <!-- RFC 8288 link relations for agent/API discovery (HTML equivalent of HTTP Link headers) -->
+  <Fragment slot="head">
+    <link rel="api-catalog" href="/.well-known/api-catalog.json" type="application/json" />
+    <link rel="describedby" href="/data/catalog.json" type="application/json" />
+    <link rel="service-desc" href="https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/" type="application/json" />
+    <link rel="alternate" href="/index.md" type="text/markdown" title="Markdown version" />
+    <link rel="alternate" href="/llms.txt" type="text/plain" title="LLM-readable overview" />
+  </Fragment>
   <!-- Hero -->
   <div class="relative overflow-hidden">
     <div class="hero-dots absolute inset-0 pointer-events-none"></div>
@@ -400,12 +408,16 @@ const filterData = groupedData.map(cat => ({
     return li;
   }
 
-  function renderResults(items) {
+  function renderResults(items, query) {
     if (!resultsList) return;
     while (resultsList.firstChild) resultsList.removeChild(resultsList.firstChild);
 
     if (!items.length) {
-      resultsList.classList.add('hidden');
+      const li = document.createElement('li');
+      li.className = 'px-4 py-4 text-sm text-gray-400 dark:text-slate-500 text-center';
+      li.textContent = `No schemas found for "${query}"`;
+      resultsList.appendChild(li);
+      resultsList.classList.remove('hidden');
       if (hints) hints.classList.add('hidden');
       return;
     }
@@ -429,7 +441,7 @@ const filterData = groupedData.map(cat => ({
     const matches = allResources.filter(r =>
       r.kind.toLowerCase().includes(q) || r.group.toLowerCase().includes(q)
     );
-    renderResults(matches);
+    renderResults(matches, q);
   });
 
   input?.addEventListener('keydown', (e) => {
@@ -437,11 +449,17 @@ const filterData = groupedData.map(cat => ({
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       activeIndex = Math.min(activeIndex + 1, items.length - 1);
-      items.forEach((el, i) => el.classList.toggle('bg-blue-50', i === activeIndex));
+      items.forEach((el, i) => {
+        el.classList.toggle('bg-blue-50', i === activeIndex);
+        el.classList.toggle('dark:bg-blue-900/20', i === activeIndex);
+      });
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       activeIndex = Math.max(activeIndex - 1, -1);
-      items.forEach((el, i) => el.classList.toggle('bg-blue-50', i === activeIndex));
+      items.forEach((el, i) => {
+        el.classList.toggle('bg-blue-50', i === activeIndex);
+        el.classList.toggle('dark:bg-blue-900/20', i === activeIndex);
+      });
     } else if (e.key === 'Enter' && activeIndex >= 0) {
       items[activeIndex]?.click();
     } else if (e.key === 'Escape') {

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -1,0 +1,77 @@
+import type { APIRoute } from 'astro';
+import catalog from '../../public/data/catalog.json';
+
+const SITE = 'https://openspec-hub.portefaix.xyz';
+
+const CATEGORIES: Array<{ name: string; match: (g: string) => boolean; description: string }> = [
+    { name: 'AWS Infrastructure',  match: g => g.includes('aws') || g.includes('amazon'),                         description: 'ACK controllers and AWS service operators' },
+    { name: 'Google Cloud',        match: g => g.includes('google') || g.includes('cnrm'),                        description: 'Config Connector CRDs for GCP services' },
+    { name: 'Azure Ecosystem',     match: g => g.includes('azure') || g.includes('microsoft'),                    description: 'Azure Service Operator resources' },
+    { name: 'GitOps & Deployment', match: g => g.includes('argoproj') || g.includes('fluxcd') || g.includes('kargo'), description: 'Argo CD, Flux CD, and Kargo resources' },
+    { name: 'Databases & Storage', match: g => ['redis','mariadb','mysql','postgresql','clickhouse','dbfor'].some(k => g.includes(k)), description: 'Database operators' },
+    { name: 'Observability',       match: g => ['monitoring','grafana','opentelemetry','prometheus'].some(k => g.includes(k)), description: 'Prometheus, Grafana, OpenTelemetry' },
+    { name: 'Networking & Mesh',   match: g => ['networking','istio','gateway','envoy'].some(k => g.includes(k)), description: 'Istio, Gateway API, Envoy' },
+    { name: 'Security',            match: g => ['security','cert-manager','external-secrets','doppler','hashicorp','sigstore','iam','kms'].some(k => g.includes(k)), description: 'cert-manager, external-secrets, Vault' },
+    { name: 'Core Kubernetes',     match: g => g.includes('k8s.io'),                                              description: 'Native Kubernetes API resources' },
+];
+
+export const GET: APIRoute = () => {
+    const groups = Object.entries(catalog.groups);
+    const totalResources = groups.reduce((n, [, res]) => n + res.length, 0);
+
+    const sections = CATEGORIES.map(cat => {
+        const matched = groups.filter(([name]) => cat.match(name));
+        if (!matched.length) return null;
+        const count = matched.reduce((n, [, res]) => n + res.length, 0);
+        const groupLinks = matched
+            .slice(0, 10)
+            .map(([name, res]) => {
+                const r = (res as { slug: string }[])[0];
+                return `  - [${name}](${SITE}/schemas/${name}) — ${res.length} resources`;
+            })
+            .join('\n');
+        const more = matched.length > 10 ? `\n  - …and ${matched.length - 10} more groups` : '';
+        return `### ${cat.name}\n\n${cat.description}. **${count} schemas** across ${matched.length} groups.\n\n${groupLinks}${more}`;
+    }).filter(Boolean).join('\n\n');
+
+    const md = `\
+# OpenSpec HUB
+
+> The central directory for Kubernetes Custom Resource Definitions. \
+${totalResources.toLocaleString()} standardised JSON schemas across \
+${groups.length} API groups and the cloud-native ecosystem.
+
+- **Source**: <https://github.com/nlamirault/openspec-hub>
+- **Catalog (JSON)**: <${SITE}/data/catalog.json>
+- **Sitemap**: <${SITE}/sitemap.xml>
+- **API Catalog**: <${SITE}/.well-known/api-catalog.json>
+
+## Schema Categories
+
+${sections}
+
+## Integration
+
+### VS Code (yaml-language-server)
+
+\`\`\`yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{group}/{kind}_{version}.json
+\`\`\`
+
+### kubeconform
+
+\`\`\`bash
+kubeconform \\
+  -schema-location 'https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{{ .Group }}/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json' \\
+  manifest.yaml
+\`\`\`
+`;
+
+    return new Response(md, {
+        headers: {
+            'Content-Type': 'text/markdown; charset=utf-8',
+            'x-markdown-tokens': String(Math.ceil(md.length / 4)),
+            'Vary': 'Accept',
+        },
+    });
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,64 @@
+import type { APIRoute } from 'astro';
+import catalog from '../../public/data/catalog.json';
+
+const SITE = 'https://openspec-hub.portefaix.xyz';
+
+export const GET: APIRoute = () => {
+    const groups = Object.entries(catalog.groups);
+    const totalResources = groups.reduce((n, [, res]) => n + res.length, 0);
+
+    const groupLines = groups
+        .map(([group, resources]) => {
+            const first = (resources as { slug: string }[])[0];
+            const url = first ? `${SITE}/schemas/${first.slug}` : `${SITE}/schemas/${group}`;
+            return `- [${group}](${url}): ${resources.length} resource${resources.length !== 1 ? 's' : ''}`;
+        })
+        .join('\n');
+
+    const md = `\
+# OpenSpec HUB
+
+> The central directory for Kubernetes Custom Resource Definitions. \
+${totalResources.toLocaleString()} standardised JSON schemas across \
+${groups.length} API groups covering AWS, GCP, Azure, GitOps, databases, \
+observability, networking, security, and core Kubernetes.
+
+## Overview
+
+- **Total schemas**: ${totalResources.toLocaleString()}
+- **API groups**: ${groups.length}
+- **Source**: <https://github.com/nlamirault/openspec-hub>
+- **Raw schema base**: <https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/>
+- **Machine-readable catalog**: <${SITE}/data/catalog.json>
+- **Sitemap**: <${SITE}/sitemap.xml>
+
+## Using schemas
+
+Add a \`$schema\` reference to any Kubernetes manifest:
+
+\`\`\`yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{api-group}/{kind}_{version}.json
+apiVersion: example.io/v1
+kind: MyResource
+\`\`\`
+
+With kubeconform:
+
+\`\`\`bash
+kubeconform \\
+  -schema-location 'https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas/{{ .Group }}/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json' \\
+  manifest.yaml
+\`\`\`
+
+## API Groups
+
+${groupLines}
+`;
+
+    return new Response(md, {
+        headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'x-markdown-tokens': String(Math.ceil(md.length / 4)),
+        },
+    });
+};

--- a/src/pages/schemas/[...slug].astro
+++ b/src/pages/schemas/[...slug].astro
@@ -49,8 +49,13 @@ export async function getStaticPaths() {
 
 const { pageType, group, resources, file, version, kind, siblingVersions } = Astro.props;
 
+const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/nlamirault/openspec-hub/main/schemas';
+
 let schema: any;
 let schemaDescription: string;
+let schemaUrl: string;
+let yamlSnippet: string;
+let kubeconformSnippet: string;
 
 if (pageType === 'resource') {
     const fullPath = path.resolve('schemas', file!);
@@ -61,6 +66,9 @@ if (pageType === 'resource') {
         schema = { title: kind, description: 'Could not parse JSON schema' };
     }
     schemaDescription = schema.description || `Kubernetes CRD schema for ${kind} (${version}) in ${group}`;
+    schemaUrl = `${GITHUB_RAW_BASE}/${file}`;
+    yamlSnippet = `# yaml-language-server: $schema=${schemaUrl}`;
+    kubeconformSnippet = `kubeconform -schema-location '${GITHUB_RAW_BASE}/{{ .Group }}/{{ .ResourceKind }}_{{ .ResourceAPIVersion }}.json' manifest.yaml`;
 }
 
 // For group page: group resources by version
@@ -151,9 +159,44 @@ const sortedVersions = Object.keys(resourcesByVersion).sort((a, b) => b.localeCo
             <h1 class="text-4xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-4">
                 {kind}
             </h1>
-            <p class="text-lg text-gray-600 dark:text-slate-400 leading-relaxed font-medium">
+            <p class="text-lg text-gray-600 dark:text-slate-400 leading-relaxed font-medium mb-6">
                 {schema.description || 'No description provided.'}
             </p>
+
+            <!-- Schema URL + usage snippet -->
+            <div class="rounded-2xl border border-gray-100 dark:border-slate-800 bg-gray-50 dark:bg-slate-900/60 p-4 space-y-3">
+                <div class="flex items-center gap-2">
+                    <span class="text-[10px] font-black uppercase tracking-widest text-gray-400 dark:text-slate-500">Schema URL</span>
+                </div>
+                <div class="flex items-center gap-2">
+                    <code id="schema-url-text" class="flex-1 text-[11px] font-mono text-blue-600 dark:text-blue-400 bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg px-3 py-2 truncate select-all">
+                        {schemaUrl}
+                    </code>
+                    <button
+                        id="copy-url-btn"
+                        title="Copy schema URL"
+                        class="shrink-0 px-3 py-2 text-[11px] font-semibold bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 text-gray-600 dark:text-slate-300 rounded-lg hover:border-blue-300 dark:hover:border-blue-600 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                    >
+                        Copy
+                    </button>
+                </div>
+                <details class="group">
+                    <summary class="text-[10px] font-bold uppercase tracking-widest text-gray-400 dark:text-slate-500 cursor-pointer hover:text-blue-500 dark:hover:text-blue-400 transition-colors list-none flex items-center gap-1 select-none">
+                        <span class="group-open:rotate-90 transition-transform inline-block">▶</span>
+                        Usage examples
+                    </summary>
+                    <div class="mt-3 space-y-2">
+                        <div>
+                            <div class="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-slate-500 mb-1">VS Code / yaml-language-server</div>
+                            <code class="block text-[11px] font-mono text-gray-600 dark:text-slate-400 bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 rounded-lg px-3 py-2 whitespace-pre-wrap break-all">{yamlSnippet}</code>
+                        </div>
+                        <div>
+                            <div class="text-[9px] font-black uppercase tracking-widest text-gray-400 dark:text-slate-500 mb-1">kubeconform</div>
+                            <code class="block text-[11px] font-mono text-gray-600 dark:text-slate-400 bg-white dark:bg-slate-800 border border-gray-100 dark:border-slate-700 rounded-lg px-3 py-2 whitespace-pre-wrap break-all">{kubeconformSnippet}</code>
+                        </div>
+                    </div>
+                </details>
+            </div>
         </header>
 
         <section>
@@ -178,10 +221,33 @@ const sortedVersions = Object.keys(resourcesByVersion).sort((a, b) => b.localeCo
             <div class="text-[10px] text-gray-400 dark:text-slate-500 font-bold uppercase tracking-widest">
                 OpenSpec HUB
             </div>
-            <div class="text-[10px] text-gray-300 dark:text-slate-600 font-mono">
-                Source: {file}
-            </div>
+            <a
+                href={`https://github.com/nlamirault/openspec-hub/blob/main/schemas/${file}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-[10px] text-gray-300 dark:text-slate-600 font-mono hover:text-blue-500 dark:hover:text-blue-400 transition-colors"
+                title="View source on GitHub"
+            >
+                View source ↗
+            </a>
         </footer>
     </div>
 </Layout>
 )}
+
+<script>
+    const btn = document.getElementById('copy-url-btn');
+    const urlText = document.getElementById('schema-url-text');
+    if (btn && urlText) {
+        btn.addEventListener('click', async () => {
+            const url = urlText.textContent?.trim() ?? '';
+            await navigator.clipboard.writeText(url);
+            btn.textContent = 'Copied!';
+            btn.classList.add('text-green-600', 'dark:text-green-400', 'border-green-300', 'dark:border-green-700');
+            setTimeout(() => {
+                btn.textContent = 'Copy';
+                btn.classList.remove('text-green-600', 'dark:text-green-400', 'border-green-300', 'dark:border-green-700');
+            }, 2000);
+        });
+    }
+</script>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from 'astro';
+import catalog from '../../public/data/catalog.json';
+
+const SITE = 'https://openspec-hub.portefaix.xyz';
+
+function buildUrls(): string[] {
+    const urls: string[] = ['/'];
+    for (const [group, resources] of Object.entries(catalog.groups)) {
+        urls.push(`/schemas/${group}`);
+        for (const res of resources as { slug: string }[]) {
+            urls.push(`/schemas/${res.slug}`);
+        }
+    }
+    return urls;
+}
+
+export const GET: APIRoute = () => {
+    const entries = buildUrls();
+    const xml = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        ...entries.map(u => `  <url><loc>${SITE}${u}</loc></url>`),
+        '</urlset>',
+    ].join('\n');
+
+    return new Response(xml, {
+        headers: { 'Content-Type': 'application/xml; charset=utf-8' },
+    });
+};


### PR DESCRIPTION
## Summary

- Add SEO foundations: sitemap.xml endpoint, canonical URLs, og:url, robots.txt with AI bot rules and Content Signals directives
- Implement agent discoverability features: RFC 8288 Link headers, API catalog (/.well-known/api-catalog.json), agent skills discovery index (/.well-known/agent-skills/index.json), markdown content negotiation (llms.txt, index.md, Cloudflare Pages middleware)
- Add UX improvements: 404 page, schema URL copy button with usage snippets, dark-mode keyboard nav fix, hero search empty state
- Add Claude Code project skill (.claude/skills/) for schema lookup from OpenSpec HUB
- Update production domain to openspec-hub.portefaix.xyz throughout all endpoints and static files