### PR TITLE
feat(renovate): add schema rebuild workflow for renovate prs

### DIFF
--- a/.github/workflows/renovate-rebuild-schemas.yml
+++ b/.github/workflows/renovate-rebuild-schemas.yml
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+---
+
+name: Renovate / Rebuild Schemas
+
+on:
+  pull_request:
+    paths:
+    - 'crds/*.sh'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to rebuild schemas for (e.g. renovate/argo-cd-3.x)'
+        required: true
+        type: string
+      crd_scripts:
+        description: 'Space-separated CRD scripts to rebuild (e.g. "crds/argo-cd.sh crds/cert-manager.sh"). Leave empty to auto-detect changes vs main.'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild-schemas:
+    name: Rebuild schemas for changed CRDs
+    runs-on: ubuntu-latest
+    if: github.actor == 'renovate[bot]' || github.event_name == 'workflow_dispatch'
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        ref: ${{ inputs.branch || github.head_ref }}
+        fetch-depth: 0
+
+    - name: Monitor GitHub Actions permissions
+      uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      with:
+        config: ${{ vars.PERMISSIONS_CONFIG }}
+
+    - name: Install yq
+      uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5
+
+    - name: Install kustomize
+      uses: imranismail/setup-kustomize@53f941b41dca13ed61874bbc6b4b6e1562877530 # v3.0.0
+
+    - name: Install kubectl
+      uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+
+    - name: Install kubectl-slice
+      run: |
+        go install github.com/patrickdappollonio/kubectl-slice@latest
+        echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
+
+    - name: Detect CRD scripts to rebuild
+      id: changed
+      env:
+        INPUT_SCRIPTS: ${{ inputs.crd_scripts }}
+      run: |
+        if [[ -n "${INPUT_SCRIPTS}" ]]; then
+          FILES="${INPUT_SCRIPTS}"
+        else
+          BASE="${GITHUB_BASE_REF:-main}"
+          git fetch origin "${BASE}"
+          FILES=$(git diff --name-only "origin/${BASE}...HEAD" -- 'crds/*.sh' | tr '\n' ' ')
+        fi
+        echo "files=${FILES}" >> "${GITHUB_OUTPUT}"
+        if [[ -n "${FILES// /}" ]]; then
+          echo "any_changed=true" >> "${GITHUB_OUTPUT}"
+        else
+          echo "any_changed=false" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: Build changed CRDs
+      if: steps.changed.outputs.any_changed == 'true'
+      env:
+        CHANGED_FILES: ${{ steps.changed.outputs.files }}
+      run: |
+        for crd_script in ${CHANGED_FILES}; do
+          echo "::group::Building ${crd_script}"
+          make build CRD="${crd_script}"
+          echo "::endgroup::"
+        done
+
+    - name: Commit and push updated schemas
+      if: steps.changed.outputs.any_changed == 'true'
+      env:
+        TARGET_BRANCH: ${{ inputs.branch || github.head_ref }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add schemas/
+        if git diff --cached --quiet; then
+          echo "No schema changes to commit — schemas already up to date."
+        else
+          git commit -m "chore(schemas): rebuild schemas for Renovate CRD bump"
+          git push origin "HEAD:${TARGET_BRANCH}"
+        fi
+
+    - name: No CRD scripts changed
+      if: steps.changed.outputs.any_changed == 'false'
+      run: echo "No CRD scripts changed — skipping build."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/renovate-rebuild-schemas.yml` implementing Option C from issue #225
- Automatically rebuilds JSON schemas when Renovate bumps a `VERSION` in `crds/*.sh`, making Renovate PRs self-contained
- Supports `workflow_dispatch` for on-demand manual re-runs with a target branch and optional explicit script list

Closes: #225 