### PR TITLE
fix(catalog): use sort_keys=True instead of manual dict sort

### DIFF
--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -60,7 +60,7 @@ def generate_catalog(schemas_dir, output_dir):
         json.dump(sorted_catalog, f, indent=2)
 
     with open(os.path.join(output_dir, "titles.json"), "w") as f:
-        json.dump(dict(sorted(titles.items())), f, indent=2)
+        json.dump(titles, f, indent=2, sort_keys=True)
 
     print(f"Catalog generated in {output_dir}")
 

--- a/scripts/validate-schemas.sh
+++ b/scripts/validate-schemas.sh
@@ -33,7 +33,7 @@ failed_files=()
 
 while IFS= read -r schema_file; do
   total=$((total + 1))
-  filename=$(basename ${schema_file})
+  filename=$(basename "${schema_file}")
   log_info "[schema] Validating: ${filename}"
   if ! jsonschema-cli validate --draft "${DRAFT}" "${schema_file}" 2>/dev/null; then
     log_warn "[schema] Invalid: ${filename} - File: ${schema_file}"


### PR DESCRIPTION
## Summary

- Replace `dict(sorted(titles.items()))` with `json.dump(..., sort_keys=True)`
- `sort_keys=True` is the canonical Python idiom for deterministic JSON serialization
- Avoids unnecessary dict allocation; also sorts recursively through nested structures