### PR TITLE
feat(crd): add tuppr CRD schemas for kubernetes and talos upgrades

### DIFF
--- a/crds/tuppr.sh
+++ b/crds/tuppr.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+export choice=individual
+export FILES=(
+  "tuppr.home-operations.com_kubernetesupgrades.yaml"
+  "tuppr.home-operations.com_talosupgrades.yaml"
+)
+
+# renovate: datasource=github-tags depName=home-operations/tuppr
+export VERSION=0.1.35
+
+function generate_url {
+  local crd_file=$1
+  echo "https://raw.githubusercontent.com/home-operations/tuppr/refs/tags/${VERSION}/config/crd/bases/${crd_file}"
+}

--- a/public/data/catalog.json
+++ b/public/data/catalog.json
@@ -16992,6 +16992,20 @@
         "slug": "traefik.io/v1alpha1/traefikservice"
       }
     ],
+    "tuppr.home-operations.com": [
+      {
+        "kind": "kubernetesupgrade",
+        "version": "v1alpha1",
+        "file": "tuppr.home-operations.com/kubernetesupgrade_v1alpha1.json",
+        "slug": "tuppr.home-operations.com/v1alpha1/kubernetesupgrade"
+      },
+      {
+        "kind": "talosupgrade",
+        "version": "v1alpha1",
+        "file": "tuppr.home-operations.com/talosupgrade_v1alpha1.json",
+        "slug": "tuppr.home-operations.com/v1alpha1/talosupgrade"
+      }
+    ],
     "vertexai.cnrm.cloud.google.com": [
       {
         "kind": "vertexaidataset",

--- a/schemas/tuppr.home-operations.com/kubernetesupgrade_v1alpha1.json
+++ b/schemas/tuppr.home-operations.com/kubernetesupgrade_v1alpha1.json
@@ -1,0 +1,399 @@
+{
+  "description": "KubernetesUpgrade is the Schema for the kubernetesupgrades API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "KubernetesUpgradeSpec defines the desired state of KubernetesUpgrade",
+      "properties": {
+        "healthChecks": {
+          "description": "HealthChecks defines a list of CEL-based health checks to perform before the upgrade",
+          "items": {
+            "description": "HealthCheck defines a CEL-based health check",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion of the resource to check",
+                "type": "string"
+              },
+              "description": {
+                "description": "Description of what this check validates (for status/logging)",
+                "type": "string"
+              },
+              "expr": {
+                "description": "CEL expression that must evaluate to true for the check to pass\nThe resource object is available as 'object' and status as 'status'",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the resource to check",
+                "type": "string"
+              },
+              "labelSelector": {
+                "description": "LabelSelector selects resources to check when name is empty",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic"
+              },
+              "name": {
+                "description": "Name of the specific resource (optional, if empty checks all resources of this kind)",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the resource (optional, for namespaced resources)",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout for this health check",
+                "minLength": 2,
+                "pattern": "^([0-9]+[smh])+$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "apiVersion",
+              "expr",
+              "kind"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "kubernetes": {
+          "description": "Kubernetes defines the target Kubernetes configuration",
+          "properties": {
+            "endpoint": {
+              "description": "Endpoint overrides the Kubernetes API URL the upgrade Job queries.\nDefaults to the in-cluster apiserver ClusterIP, which avoids CoreDNS.",
+              "pattern": "^https://[^/\\s]+",
+              "type": "string"
+            },
+            "imageRepository": {
+              "description": "ImageRepository overrides the registry+path prefix for Kubernetes component\nimages. When set, each component (kube-apiserver, kube-controller-manager,\nkube-scheduler, kube-proxy, kubelet) is pulled from\n\"<imageRepository>/<component>:<version>\".",
+              "type": "string"
+            },
+            "version": {
+              "description": "Version is the target Kubernetes version to upgrade to (e.g., \"v1.34.0\")",
+              "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9\\-\\.]+)?$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "version"
+          ],
+          "type": "object"
+        },
+        "maintenance": {
+          "description": "Maintenance configuration behavior for upgrade operations",
+          "properties": {
+            "windows": {
+              "items": {
+                "properties": {
+                  "duration": {
+                    "description": "How long the window stays open (e.g., \"4h\", \"2h30m\")",
+                    "pattern": "^([0-9]+[smh])+$",
+                    "type": "string"
+                  },
+                  "start": {
+                    "description": "Cron expression (5-field): minute hour day-of-month month day-of-week",
+                    "minLength": 9,
+                    "type": "string"
+                  },
+                  "timezone": {
+                    "default": "UTC",
+                    "description": "IANA timezone (e.g., \"UTC\", \"Europe/Paris\")",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "duration",
+                  "start"
+                ],
+                "type": "object"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "talosctl": {
+          "description": "Talosctl specifies the talosctl configuration for upgrade operations",
+          "properties": {
+            "image": {
+              "description": "Image specifies the talosctl container image",
+              "properties": {
+                "pullPolicy": {
+                  "default": "IfNotPresent",
+                  "description": "PullPolicy describes a policy for if/when to pull a container image",
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "IfNotPresent"
+                  ],
+                  "type": "string"
+                },
+                "repository": {
+                  "default": "ghcr.io/siderolabs/talosctl",
+                  "description": "Repository is the talosctl container image repository",
+                  "type": "string"
+                },
+                "tag": {
+                  "description": "Tag is the talosctl container image tag\nIf not specified, defaults to the target version",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "kubernetes"
+      ],
+      "type": "object"
+    },
+    "status": {
+      "description": "KubernetesUpgradeStatus defines the observed state of KubernetesUpgrade",
+      "properties": {
+        "completedAt": {
+          "description": "CompletedAt is the time the upgrade reached a terminal phase",
+          "format": "date-time",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Conditions report the upgrade's \"Progressing\" and \"Ready\" status.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "controllerNode": {
+          "description": "ControllerNode is the controller node being used for the upgrade",
+          "type": "string"
+        },
+        "currentVersion": {
+          "description": "CurrentVersion is the current Kubernetes version detected in the cluster",
+          "type": "string"
+        },
+        "history": {
+          "description": "History records past version transitions on this CR, newest first",
+          "items": {
+            "description": "UpgradeHistoryEntry records a single completed version transition",
+            "properties": {
+              "completedAt": {
+                "description": "CompletedAt is when the run reached its terminal phase",
+                "format": "date-time",
+                "type": "string"
+              },
+              "fromVersion": {
+                "description": "FromVersion is the cluster version detected at the start of the run",
+                "type": "string"
+              },
+              "lastError": {
+                "description": "LastError is the final error message when Phase is Failed",
+                "type": "string"
+              },
+              "phase": {
+                "description": "Phase is the terminal phase reached (Completed or Failed)",
+                "enum": [
+                  "Pending",
+                  "HealthChecking",
+                  "PreHook",
+                  "Draining",
+                  "Upgrading",
+                  "Rebooting",
+                  "PostHook",
+                  "Completed",
+                  "Failed",
+                  "MaintenanceWindow"
+                ],
+                "type": "string"
+              },
+              "retries": {
+                "description": "Retries is the number of retries recorded during the run",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "startedAt": {
+                "description": "StartedAt is when the run began",
+                "format": "date-time",
+                "type": "string"
+              },
+              "toVersion": {
+                "description": "ToVersion is the spec-target version at the time of completion",
+                "type": "string"
+              }
+            },
+            "required": [
+              "completedAt",
+              "phase",
+              "startedAt",
+              "toVersion"
+            ],
+            "type": "object"
+          },
+          "maxItems": 10,
+          "type": "array"
+        },
+        "jobName": {
+          "description": "JobName is the name of the job handling the upgrade",
+          "type": "string"
+        },
+        "lastError": {
+          "description": "LastError contains the last error message",
+          "type": "string"
+        },
+        "lastUpdated": {
+          "description": "LastUpdated timestamp of last status update",
+          "format": "date-time",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message provides details about the current state",
+          "type": "string"
+        },
+        "nextMaintenanceWindow": {
+          "description": "NextMaintenanceWindow reflect the next time a maintenance can happen",
+          "format": "date-time",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed spec",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of the upgrade",
+          "enum": [
+            "Pending",
+            "HealthChecking",
+            "PreHook",
+            "Draining",
+            "Upgrading",
+            "Rebooting",
+            "PostHook",
+            "Completed",
+            "Failed",
+            "MaintenanceWindow"
+          ],
+          "type": "string"
+        },
+        "retries": {
+          "description": "Retries is the number of times the upgrade was attempted",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "startedAt": {
+          "description": "StartedAt is the time the current upgrade attempt began",
+          "format": "date-time",
+          "type": "string"
+        },
+        "targetVersion": {
+          "description": "TargetVersion is the target version from the spec",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/schemas/tuppr.home-operations.com/talosupgrade_v1alpha1.json
+++ b/schemas/tuppr.home-operations.com/talosupgrade_v1alpha1.json
@@ -1,0 +1,4102 @@
+{
+  "description": "TalosUpgrade is the Schema for the talosupgrades API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "TalosUpgradeSpec defines the desired state of TalosUpgrade",
+      "properties": {
+        "drain": {
+          "description": "Drain configuration for the node prior to upgrade",
+          "properties": {
+            "deleteLocalData": {
+              "description": "DeleteLocalData causes the drain to continue even if there are pods using emptyDir\n(local data that will be deleted when the node is drained).",
+              "type": "boolean"
+            },
+            "disableEviction": {
+              "description": "DisableEviction forces drain to use delete, even if eviction is supported.",
+              "type": "boolean"
+            },
+            "force": {
+              "description": "Force continues even if there are pods that do not declare a controller.",
+              "type": "boolean"
+            },
+            "ignoreDaemonSets": {
+              "description": "IgnoreDaemonSets ignores DaemonSet-managed pods.",
+              "type": "boolean"
+            },
+            "skipWaitForDeleteTimeout": {
+              "description": "SkipWaitForDeleteTimeout specifies that if a pod DeletionTimestamp is older than N seconds,\nskip waiting for the pod. Seconds must be greater than 0 to skip.",
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
+        "healthChecks": {
+          "description": "HealthChecks defines a list of CEL-based health checks to perform before each node upgrade",
+          "items": {
+            "description": "HealthCheck defines a CEL-based health check",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion of the resource to check",
+                "type": "string"
+              },
+              "description": {
+                "description": "Description of what this check validates (for status/logging)",
+                "type": "string"
+              },
+              "expr": {
+                "description": "CEL expression that must evaluate to true for the check to pass\nThe resource object is available as 'object' and status as 'status'",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind of the resource to check",
+                "type": "string"
+              },
+              "labelSelector": {
+                "description": "LabelSelector selects resources to check when name is empty",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array",
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "required": [
+                        "key",
+                        "operator"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  },
+                  "matchLabels": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                  }
+                },
+                "type": "object",
+                "x-kubernetes-map-type": "atomic"
+              },
+              "name": {
+                "description": "Name of the specific resource (optional, if empty checks all resources of this kind)",
+                "type": "string"
+              },
+              "namespace": {
+                "description": "Namespace of the resource (optional, for namespaced resources)",
+                "type": "string"
+              },
+              "timeout": {
+                "description": "Timeout for this health check",
+                "minLength": 2,
+                "pattern": "^([0-9]+[smh])+$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "apiVersion",
+              "expr",
+              "kind"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "hooks": {
+          "description": "Hooks configures pre/post-upgrade Jobs (e.g. `ceph osd set/unset noout`).",
+          "properties": {
+            "post": {
+              "description": "Post runs sequentially after the upgrade reaches a terminal state.\nAlways runs if any pre-hook was attempted; failures don't override the\nupgrade outcome.",
+              "items": {
+                "description": "HookSpec describes a Job to run before or after a TalosUpgrade run.",
+                "properties": {
+                  "activeDeadlineSeconds": {
+                    "description": "ActiveDeadlineSeconds for the hook Job. Defaults to 600.",
+                    "format": "int64",
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "args": {
+                    "description": "Args are passed to the entrypoint.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "backoffLimit": {
+                    "description": "BackoffLimit for the hook Job. Defaults to 0 (fail fast, no retries).",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "command": {
+                    "description": "Command overrides the image entrypoint.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "env": {
+                    "description": "Env are environment variables for the hook container.",
+                    "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                          "type": "string"
+                        },
+                        "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                          "properties": {
+                            "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key to select.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "fileKeyRef": {
+                              "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "default": false,
+                                  "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                                  "type": "boolean"
+                                },
+                                "path": {
+                                  "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                                  "type": "string"
+                                },
+                                "volumeName": {
+                                  "description": "The name of the volume mount containing the env file.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path",
+                                "volumeName"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "envFrom": {
+                    "description": "EnvFrom sources environment variables from ConfigMaps or Secrets.",
+                    "items": {
+                      "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                      "properties": {
+                        "configMapRef": {
+                          "description": "The ConfigMap to select from",
+                          "properties": {
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "prefix": {
+                          "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "The Secret to select from",
+                          "properties": {
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "image": {
+                    "description": "Image is the container image to run.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "imagePullPolicy": {
+                    "default": "IfNotPresent",
+                    "description": "ImagePullPolicy for the hook container.",
+                    "enum": [
+                      "Always",
+                      "Never",
+                      "IfNotPresent"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is a human-readable identifier, unique within its pre/post list.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "serviceAccountName": {
+                    "description": "ServiceAccountName for the hook pod. Defaults to \"default\".",
+                    "type": "string"
+                  },
+                  "volumeMounts": {
+                    "description": "VolumeMounts are container volume mounts.",
+                    "items": {
+                      "description": "VolumeMount describes a mounting of a Volume within a container.",
+                      "properties": {
+                        "mountPath": {
+                          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                          "type": "string"
+                        },
+                        "mountPropagation": {
+                          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "This must match the Name of a Volume.",
+                          "type": "string"
+                        },
+                        "readOnly": {
+                          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                          "type": "boolean"
+                        },
+                        "recursiveReadOnly": {
+                          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                          "type": "string"
+                        },
+                        "subPath": {
+                          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                          "type": "string"
+                        },
+                        "subPathExpr": {
+                          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "volumes": {
+                    "description": "Volumes are pod-level volumes (typically Secrets / ConfigMaps).",
+                    "items": {
+                      "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                      "properties": {
+                        "awsElasticBlockStore": {
+                          "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                              "type": "string"
+                            },
+                            "partition": {
+                              "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "readOnly": {
+                              "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                              "type": "boolean"
+                            },
+                            "volumeID": {
+                              "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "volumeID"
+                          ],
+                          "type": "object"
+                        },
+                        "azureDisk": {
+                          "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
+                          "properties": {
+                            "cachingMode": {
+                              "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                              "type": "string"
+                            },
+                            "diskName": {
+                              "description": "diskName is the Name of the data disk in the blob storage",
+                              "type": "string"
+                            },
+                            "diskURI": {
+                              "description": "diskURI is the URI of data disk in the blob storage",
+                              "type": "string"
+                            },
+                            "fsType": {
+                              "default": "ext4",
+                              "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "default": false,
+                              "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "diskName",
+                            "diskURI"
+                          ],
+                          "type": "object"
+                        },
+                        "azureFile": {
+                          "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
+                          "properties": {
+                            "readOnly": {
+                              "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "secretName": {
+                              "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                              "type": "string"
+                            },
+                            "shareName": {
+                              "description": "shareName is the azure share Name",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretName",
+                            "shareName"
+                          ],
+                          "type": "object"
+                        },
+                        "cephfs": {
+                          "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                          "properties": {
+                            "monitors": {
+                              "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "path": {
+                              "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "type": "boolean"
+                            },
+                            "secretFile": {
+                              "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "user": {
+                              "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "monitors"
+                          ],
+                          "type": "object"
+                        },
+                        "cinder": {
+                          "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "volumeID": {
+                              "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "volumeID"
+                          ],
+                          "type": "object"
+                        },
+                        "configMap": {
+                          "description": "configMap represents a configMap that should populate this volume",
+                          "properties": {
+                            "defaultMode": {
+                              "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "csi": {
+                          "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                          "properties": {
+                            "driver": {
+                              "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                              "type": "string"
+                            },
+                            "fsType": {
+                              "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                              "type": "string"
+                            },
+                            "nodePublishSecretRef": {
+                              "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "readOnly": {
+                              "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                              "type": "boolean"
+                            },
+                            "volumeAttributes": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "driver"
+                          ],
+                          "type": "object"
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                          "properties": {
+                            "defaultMode": {
+                              "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "items": {
+                              "description": "Items is a list of downward API volume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "emptyDir": {
+                          "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                          "properties": {
+                            "medium": {
+                              "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                              "type": "string"
+                            },
+                            "sizeLimit": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "ephemeral": {
+                          "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                          "properties": {
+                            "volumeClaimTemplate": {
+                              "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                              "properties": {
+                                "metadata": {
+                                  "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                                  "type": "object"
+                                },
+                                "spec": {
+                                  "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                                  "properties": {
+                                    "accessModes": {
+                                      "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "dataSource": {
+                                      "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                      "properties": {
+                                        "apiGroup": {
+                                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind is the type of resource being referenced",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of resource being referenced",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "dataSourceRef": {
+                                      "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                      "properties": {
+                                        "apiGroup": {
+                                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind is the type of resource being referenced",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of resource being referenced",
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "resources": {
+                                      "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                      "properties": {
+                                        "limits": {
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object"
+                                        },
+                                        "requests": {
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "selector": {
+                                      "description": "selector is a label query over volumes to consider for binding.",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "storageClassName": {
+                                      "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                      "type": "string"
+                                    },
+                                    "volumeAttributesClassName": {
+                                      "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+                                      "type": "string"
+                                    },
+                                    "volumeMode": {
+                                      "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                      "type": "string"
+                                    },
+                                    "volumeName": {
+                                      "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "spec"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "fc": {
+                          "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "lun": {
+                              "description": "lun is Optional: FC target lun number",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "readOnly": {
+                              "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "targetWWNs": {
+                              "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "wwids": {
+                              "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "flexVolume": {
+                          "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                          "properties": {
+                            "driver": {
+                              "description": "driver is the name of the driver to use for this volume.",
+                              "type": "string"
+                            },
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                              "type": "string"
+                            },
+                            "options": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "options is Optional: this field holds extra command options if any.",
+                              "type": "object"
+                            },
+                            "readOnly": {
+                              "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "required": [
+                            "driver"
+                          ],
+                          "type": "object"
+                        },
+                        "flocker": {
+                          "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                          "properties": {
+                            "datasetName": {
+                              "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                              "type": "string"
+                            },
+                            "datasetUUID": {
+                              "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "gcePersistentDisk": {
+                          "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                              "type": "string"
+                            },
+                            "partition": {
+                              "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "pdName": {
+                              "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "pdName"
+                          ],
+                          "type": "object"
+                        },
+                        "gitRepo": {
+                          "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                          "properties": {
+                            "directory": {
+                              "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                              "type": "string"
+                            },
+                            "repository": {
+                              "description": "repository is the URL",
+                              "type": "string"
+                            },
+                            "revision": {
+                              "description": "revision is the commit hash for the specified revision.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "repository"
+                          ],
+                          "type": "object"
+                        },
+                        "glusterfs": {
+                          "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.",
+                          "properties": {
+                            "endpoints": {
+                              "description": "endpoints is the endpoint name that details Glusterfs topology.",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "endpoints",
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        "hostPath": {
+                          "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                          "properties": {
+                            "path": {
+                              "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        "image": {
+                          "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                          "properties": {
+                            "pullPolicy": {
+                              "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                              "type": "string"
+                            },
+                            "reference": {
+                              "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "iscsi": {
+                          "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi",
+                          "properties": {
+                            "chapAuthDiscovery": {
+                              "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                              "type": "boolean"
+                            },
+                            "chapAuthSession": {
+                              "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                              "type": "boolean"
+                            },
+                            "fsType": {
+                              "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                              "type": "string"
+                            },
+                            "initiatorName": {
+                              "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                              "type": "string"
+                            },
+                            "iqn": {
+                              "description": "iqn is the target iSCSI Qualified Name.",
+                              "type": "string"
+                            },
+                            "iscsiInterface": {
+                              "default": "default",
+                              "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                              "type": "string"
+                            },
+                            "lun": {
+                              "description": "lun represents iSCSI Target Lun number.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "portals": {
+                              "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "targetPortal": {
+                              "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "iqn",
+                            "lun",
+                            "targetPortal"
+                          ],
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "nfs": {
+                          "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                          "properties": {
+                            "path": {
+                              "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                              "type": "boolean"
+                            },
+                            "server": {
+                              "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path",
+                            "server"
+                          ],
+                          "type": "object"
+                        },
+                        "persistentVolumeClaim": {
+                          "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                          "properties": {
+                            "claimName": {
+                              "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "claimName"
+                          ],
+                          "type": "object"
+                        },
+                        "photonPersistentDisk": {
+                          "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "pdID": {
+                              "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "pdID"
+                          ],
+                          "type": "object"
+                        },
+                        "portworxVolume": {
+                          "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "volumeID": {
+                              "description": "volumeID uniquely identifies a Portworx volume",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "volumeID"
+                          ],
+                          "type": "object"
+                        },
+                        "projected": {
+                          "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                          "properties": {
+                            "defaultMode": {
+                              "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "sources": {
+                              "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                              "items": {
+                                "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                                "properties": {
+                                  "clusterTrustBundle": {
+                                    "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "name": {
+                                        "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                                        "type": "boolean"
+                                      },
+                                      "path": {
+                                        "description": "Relative path from the volume root to write the bundle.",
+                                        "type": "string"
+                                      },
+                                      "signerName": {
+                                        "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "configMap": {
+                                    "description": "configMap information about the configMap data to project",
+                                    "properties": {
+                                      "items": {
+                                        "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                        "items": {
+                                          "description": "Maps a string key to a path within a volume.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the key to project.",
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "path"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "downwardAPI": {
+                                    "description": "downwardAPI information about the downwardAPI data to project",
+                                    "properties": {
+                                      "items": {
+                                        "description": "Items is a list of DownwardAPIVolume file",
+                                        "items": {
+                                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                          "properties": {
+                                            "fieldRef": {
+                                              "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "description": "Path of the field to select in the specified API version.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "fieldPath"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "mode": {
+                                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                              "type": "string"
+                                            },
+                                            "resourceFieldRef": {
+                                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                              "properties": {
+                                                "containerName": {
+                                                  "description": "Container name: required for volumes, optional for env vars",
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "description": "Required: resource to select",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "resource"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic"
+                                            }
+                                          },
+                                          "required": [
+                                            "path"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "podCertificate": {
+                                    "description": "Projects an auto-rotating credential bundle (private key and certificate\nchain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a\nPodCertificateRequest to the named signer.  Once the signer approves the\nrequest and issues a certificate chain, Kubelet writes the key and\ncertificate chain to the pod filesystem.  The pod does not start until\ncertificates have been issued for each podCertificate projected volume\nsource in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated\nby the signer using the PodCertificateRequest.Status.BeginRefreshAt\ntimestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath\nfield, or separate files, indicated by the keyPath and\ncertificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM\nentry is the private key (in PKCS#8 format), and the remaining PEM\nentries are the certificate chain issued by the signer (typically,\nsigners will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code\ncan read it atomically.  If you use keyPath and certificateChainPath,\nyour application must make two separate file reads. If these coincide\nwith a certificate rotation, it is possible that the private key and leaf\ncertificate you read may not correspond to each other.  Your application\nwill need to check for this condition, and re-read until they are\nconsistent.\n\nThe named signer controls chooses the format of the certificate it\nissues; consult the signer implementation's documentation to learn how to\nuse the certificates it issues.",
+                                    "properties": {
+                                      "certificateChainPath": {
+                                        "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                                        "type": "string"
+                                      },
+                                      "credentialBundlePath": {
+                                        "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks.\nThe first PEM block is a PRIVATE KEY block, containing a PKCS#8 private\nkey.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued\ncertificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single\natomic read that retrieves a consistent key and certificate chain.  If you\nproject them to separate files, your application code will need to\nadditionally check that the leaf certificate was issued to the key.",
+                                        "type": "string"
+                                      },
+                                      "keyPath": {
+                                        "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                                        "type": "string"
+                                      },
+                                      "keyType": {
+                                        "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\",\n\"ECDSAP521\", and \"ED25519\".",
+                                        "type": "string"
+                                      },
+                                      "maxExpirationSeconds": {
+                                        "description": "maxExpirationSeconds is the maximum lifetime permitted for the\ncertificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it\ngenerates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver\nwill reject values shorter than 3600 (1 hour).  The maximum allowable\nvalue is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any\nlifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600\nseconds (1 hour).  This constraint is enforced by kube-apiserver.\n`kubernetes.io` signers will never issue certificates with a lifetime\nlonger than 24 hours.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "signerName": {
+                                        "description": "Kubelet's generated CSRs will be addressed to this signer.",
+                                        "type": "string"
+                                      },
+                                      "userAnnotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "userAnnotations allow pod authors to pass additional information to\nthe signer implementation.  Kubernetes does not restrict or validate this\nmetadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of\nthe PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations,\nwith the addition that all keys must be domain-prefixed. No restrictions\nare placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should\ndeny requests that contain keys they do not recognize.",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "keyType",
+                                      "signerName"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "secret": {
+                                    "description": "secret information about the secret data to project",
+                                    "properties": {
+                                      "items": {
+                                        "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                        "items": {
+                                          "description": "Maps a string key to a path within a volume.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the key to project.",
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "path"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "optional field specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "serviceAccountToken": {
+                                    "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                    "properties": {
+                                      "audience": {
+                                        "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                        "type": "string"
+                                      },
+                                      "expirationSeconds": {
+                                        "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "quobyte": {
+                          "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                          "properties": {
+                            "group": {
+                              "description": "group to map volume access to\nDefault is no group",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "registry": {
+                              "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                              "type": "string"
+                            },
+                            "tenant": {
+                              "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                              "type": "string"
+                            },
+                            "user": {
+                              "description": "user to map volume access to\nDefaults to serivceaccount user",
+                              "type": "string"
+                            },
+                            "volume": {
+                              "description": "volume is a string that references an already created Quobyte volume by name.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "registry",
+                            "volume"
+                          ],
+                          "type": "object"
+                        },
+                        "rbd": {
+                          "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                              "type": "string"
+                            },
+                            "image": {
+                              "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "string"
+                            },
+                            "keyring": {
+                              "default": "/etc/ceph/keyring",
+                              "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "string"
+                            },
+                            "monitors": {
+                              "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "pool": {
+                              "default": "rbd",
+                              "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "user": {
+                              "default": "admin",
+                              "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "image",
+                            "monitors"
+                          ],
+                          "type": "object"
+                        },
+                        "scaleIO": {
+                          "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                          "properties": {
+                            "fsType": {
+                              "default": "xfs",
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                              "type": "string"
+                            },
+                            "gateway": {
+                              "description": "gateway is the host address of the ScaleIO API Gateway.",
+                              "type": "string"
+                            },
+                            "protectionDomain": {
+                              "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "sslEnabled": {
+                              "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                              "type": "boolean"
+                            },
+                            "storageMode": {
+                              "default": "ThinProvisioned",
+                              "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                              "type": "string"
+                            },
+                            "storagePool": {
+                              "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                              "type": "string"
+                            },
+                            "system": {
+                              "description": "system is the name of the storage system as configured in ScaleIO.",
+                              "type": "string"
+                            },
+                            "volumeName": {
+                              "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "gateway",
+                            "secretRef",
+                            "system"
+                          ],
+                          "type": "object"
+                        },
+                        "secret": {
+                          "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                          "properties": {
+                            "defaultMode": {
+                              "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "items": {
+                              "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its keys must be defined",
+                              "type": "boolean"
+                            },
+                            "secretName": {
+                              "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "storageos": {
+                          "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "volumeName": {
+                              "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                              "type": "string"
+                            },
+                            "volumeNamespace": {
+                              "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "vsphereVolume": {
+                          "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "storagePolicyID": {
+                              "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                              "type": "string"
+                            },
+                            "storagePolicyName": {
+                              "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                              "type": "string"
+                            },
+                            "volumePath": {
+                              "description": "volumePath is the path that identifies vSphere volume vmdk",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "volumePath"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "image",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "pre": {
+              "description": "Pre runs sequentially before any node is touched.",
+              "items": {
+                "description": "HookSpec describes a Job to run before or after a TalosUpgrade run.",
+                "properties": {
+                  "activeDeadlineSeconds": {
+                    "description": "ActiveDeadlineSeconds for the hook Job. Defaults to 600.",
+                    "format": "int64",
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "args": {
+                    "description": "Args are passed to the entrypoint.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "backoffLimit": {
+                    "description": "BackoffLimit for the hook Job. Defaults to 0 (fail fast, no retries).",
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "command": {
+                    "description": "Command overrides the image entrypoint.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "env": {
+                    "description": "Env are environment variables for the hook container.",
+                    "items": {
+                      "description": "EnvVar represents an environment variable present in a Container.",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                          "type": "string"
+                        },
+                        "value": {
+                          "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                          "type": "string"
+                        },
+                        "valueFrom": {
+                          "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                          "properties": {
+                            "configMapKeyRef": {
+                              "description": "Selects a key of a ConfigMap.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key to select.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "fieldRef": {
+                              "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "fileKeyRef": {
+                              "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                              "properties": {
+                                "key": {
+                                  "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "default": false,
+                                  "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                                  "type": "boolean"
+                                },
+                                "path": {
+                                  "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                                  "type": "string"
+                                },
+                                "volumeName": {
+                                  "description": "The name of the volume mount containing the env file.",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "path",
+                                "volumeName"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "resource"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "secretKeyRef": {
+                              "description": "Selects a key of a secret in the pod's namespace",
+                              "properties": {
+                                "key": {
+                                  "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "key"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "envFrom": {
+                    "description": "EnvFrom sources environment variables from ConfigMaps or Secrets.",
+                    "items": {
+                      "description": "EnvFromSource represents the source of a set of ConfigMaps or Secrets",
+                      "properties": {
+                        "configMapRef": {
+                          "description": "The ConfigMap to select from",
+                          "properties": {
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the ConfigMap must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "prefix": {
+                          "description": "Optional text to prepend to the name of each environment variable.\nMay consist of any printable ASCII characters except '='.",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "The Secret to select from",
+                          "properties": {
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "Specify whether the Secret must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "image": {
+                    "description": "Image is the container image to run.",
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "imagePullPolicy": {
+                    "default": "IfNotPresent",
+                    "description": "ImagePullPolicy for the hook container.",
+                    "enum": [
+                      "Always",
+                      "Never",
+                      "IfNotPresent"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is a human-readable identifier, unique within its pre/post list.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "serviceAccountName": {
+                    "description": "ServiceAccountName for the hook pod. Defaults to \"default\".",
+                    "type": "string"
+                  },
+                  "volumeMounts": {
+                    "description": "VolumeMounts are container volume mounts.",
+                    "items": {
+                      "description": "VolumeMount describes a mounting of a Volume within a container.",
+                      "properties": {
+                        "mountPath": {
+                          "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                          "type": "string"
+                        },
+                        "mountPropagation": {
+                          "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "This must match the Name of a Volume.",
+                          "type": "string"
+                        },
+                        "readOnly": {
+                          "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                          "type": "boolean"
+                        },
+                        "recursiveReadOnly": {
+                          "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                          "type": "string"
+                        },
+                        "subPath": {
+                          "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                          "type": "string"
+                        },
+                        "subPathExpr": {
+                          "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "mountPath",
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "volumes": {
+                    "description": "Volumes are pod-level volumes (typically Secrets / ConfigMaps).",
+                    "items": {
+                      "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                      "properties": {
+                        "awsElasticBlockStore": {
+                          "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                              "type": "string"
+                            },
+                            "partition": {
+                              "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "readOnly": {
+                              "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                              "type": "boolean"
+                            },
+                            "volumeID": {
+                              "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "volumeID"
+                          ],
+                          "type": "object"
+                        },
+                        "azureDisk": {
+                          "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
+                          "properties": {
+                            "cachingMode": {
+                              "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                              "type": "string"
+                            },
+                            "diskName": {
+                              "description": "diskName is the Name of the data disk in the blob storage",
+                              "type": "string"
+                            },
+                            "diskURI": {
+                              "description": "diskURI is the URI of data disk in the blob storage",
+                              "type": "string"
+                            },
+                            "fsType": {
+                              "default": "ext4",
+                              "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "default": false,
+                              "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "diskName",
+                            "diskURI"
+                          ],
+                          "type": "object"
+                        },
+                        "azureFile": {
+                          "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
+                          "properties": {
+                            "readOnly": {
+                              "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "secretName": {
+                              "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                              "type": "string"
+                            },
+                            "shareName": {
+                              "description": "shareName is the azure share Name",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "secretName",
+                            "shareName"
+                          ],
+                          "type": "object"
+                        },
+                        "cephfs": {
+                          "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                          "properties": {
+                            "monitors": {
+                              "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "path": {
+                              "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "type": "boolean"
+                            },
+                            "secretFile": {
+                              "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "user": {
+                              "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "monitors"
+                          ],
+                          "type": "object"
+                        },
+                        "cinder": {
+                          "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "volumeID": {
+                              "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "volumeID"
+                          ],
+                          "type": "object"
+                        },
+                        "configMap": {
+                          "description": "configMap represents a configMap that should populate this volume",
+                          "properties": {
+                            "defaultMode": {
+                              "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "items": {
+                              "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "name": {
+                              "default": "",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "optional": {
+                              "description": "optional specify whether the ConfigMap or its keys must be defined",
+                              "type": "boolean"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "csi": {
+                          "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                          "properties": {
+                            "driver": {
+                              "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                              "type": "string"
+                            },
+                            "fsType": {
+                              "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                              "type": "string"
+                            },
+                            "nodePublishSecretRef": {
+                              "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "readOnly": {
+                              "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                              "type": "boolean"
+                            },
+                            "volumeAttributes": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                              "type": "object"
+                            }
+                          },
+                          "required": [
+                            "driver"
+                          ],
+                          "type": "object"
+                        },
+                        "downwardAPI": {
+                          "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                          "properties": {
+                            "defaultMode": {
+                              "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "items": {
+                              "description": "Items is a list of downward API volume file",
+                              "items": {
+                                "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                "properties": {
+                                  "fieldRef": {
+                                    "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "mode": {
+                                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                    "type": "string"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "emptyDir": {
+                          "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                          "properties": {
+                            "medium": {
+                              "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                              "type": "string"
+                            },
+                            "sizeLimit": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "ephemeral": {
+                          "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                          "properties": {
+                            "volumeClaimTemplate": {
+                              "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                              "properties": {
+                                "metadata": {
+                                  "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                                  "type": "object"
+                                },
+                                "spec": {
+                                  "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                                  "properties": {
+                                    "accessModes": {
+                                      "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "dataSource": {
+                                      "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                      "properties": {
+                                        "apiGroup": {
+                                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind is the type of resource being referenced",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of resource being referenced",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "name"
+                                      ],
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "dataSourceRef": {
+                                      "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                      "properties": {
+                                        "apiGroup": {
+                                          "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "Kind is the type of resource being referenced",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name is the name of resource being referenced",
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "resources": {
+                                      "description": "resources represents the minimum resources the volume should have.\nUsers are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                      "properties": {
+                                        "limits": {
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object"
+                                        },
+                                        "requests": {
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    "selector": {
+                                      "description": "selector is a label query over volumes to consider for binding.",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array",
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            },
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "type": "array",
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "storageClassName": {
+                                      "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                      "type": "string"
+                                    },
+                                    "volumeAttributesClassName": {
+                                      "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string or nil value indicates that no\nVolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,\nthis field can be reset to its previous value (including nil) to cancel the modification.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/",
+                                      "type": "string"
+                                    },
+                                    "volumeMode": {
+                                      "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                      "type": "string"
+                                    },
+                                    "volumeName": {
+                                      "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "spec"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "fc": {
+                          "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "lun": {
+                              "description": "lun is Optional: FC target lun number",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "readOnly": {
+                              "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "targetWWNs": {
+                              "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "wwids": {
+                              "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "flexVolume": {
+                          "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                          "properties": {
+                            "driver": {
+                              "description": "driver is the name of the driver to use for this volume.",
+                              "type": "string"
+                            },
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                              "type": "string"
+                            },
+                            "options": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "description": "options is Optional: this field holds extra command options if any.",
+                              "type": "object"
+                            },
+                            "readOnly": {
+                              "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "required": [
+                            "driver"
+                          ],
+                          "type": "object"
+                        },
+                        "flocker": {
+                          "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                          "properties": {
+                            "datasetName": {
+                              "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                              "type": "string"
+                            },
+                            "datasetUUID": {
+                              "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "gcePersistentDisk": {
+                          "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                              "type": "string"
+                            },
+                            "partition": {
+                              "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "pdName": {
+                              "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "pdName"
+                          ],
+                          "type": "object"
+                        },
+                        "gitRepo": {
+                          "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                          "properties": {
+                            "directory": {
+                              "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                              "type": "string"
+                            },
+                            "repository": {
+                              "description": "repository is the URL",
+                              "type": "string"
+                            },
+                            "revision": {
+                              "description": "revision is the commit hash for the specified revision.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "repository"
+                          ],
+                          "type": "object"
+                        },
+                        "glusterfs": {
+                          "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.",
+                          "properties": {
+                            "endpoints": {
+                              "description": "endpoints is the endpoint name that details Glusterfs topology.",
+                              "type": "string"
+                            },
+                            "path": {
+                              "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "endpoints",
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        "hostPath": {
+                          "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                          "properties": {
+                            "path": {
+                              "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                              "type": "string"
+                            },
+                            "type": {
+                              "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        "image": {
+                          "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                          "properties": {
+                            "pullPolicy": {
+                              "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                              "type": "string"
+                            },
+                            "reference": {
+                              "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "iscsi": {
+                          "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi",
+                          "properties": {
+                            "chapAuthDiscovery": {
+                              "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                              "type": "boolean"
+                            },
+                            "chapAuthSession": {
+                              "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                              "type": "boolean"
+                            },
+                            "fsType": {
+                              "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                              "type": "string"
+                            },
+                            "initiatorName": {
+                              "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                              "type": "string"
+                            },
+                            "iqn": {
+                              "description": "iqn is the target iSCSI Qualified Name.",
+                              "type": "string"
+                            },
+                            "iscsiInterface": {
+                              "default": "default",
+                              "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                              "type": "string"
+                            },
+                            "lun": {
+                              "description": "lun represents iSCSI Target Lun number.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "portals": {
+                              "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "targetPortal": {
+                              "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "iqn",
+                            "lun",
+                            "targetPortal"
+                          ],
+                          "type": "object"
+                        },
+                        "name": {
+                          "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "nfs": {
+                          "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                          "properties": {
+                            "path": {
+                              "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                              "type": "boolean"
+                            },
+                            "server": {
+                              "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "path",
+                            "server"
+                          ],
+                          "type": "object"
+                        },
+                        "persistentVolumeClaim": {
+                          "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                          "properties": {
+                            "claimName": {
+                              "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "claimName"
+                          ],
+                          "type": "object"
+                        },
+                        "photonPersistentDisk": {
+                          "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "pdID": {
+                              "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "pdID"
+                          ],
+                          "type": "object"
+                        },
+                        "portworxVolume": {
+                          "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "volumeID": {
+                              "description": "volumeID uniquely identifies a Portworx volume",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "volumeID"
+                          ],
+                          "type": "object"
+                        },
+                        "projected": {
+                          "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                          "properties": {
+                            "defaultMode": {
+                              "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "sources": {
+                              "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                              "items": {
+                                "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                                "properties": {
+                                  "clusterTrustBundle": {
+                                    "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array",
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              },
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "type": "array",
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "name": {
+                                        "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                                        "type": "boolean"
+                                      },
+                                      "path": {
+                                        "description": "Relative path from the volume root to write the bundle.",
+                                        "type": "string"
+                                      },
+                                      "signerName": {
+                                        "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "configMap": {
+                                    "description": "configMap information about the configMap data to project",
+                                    "properties": {
+                                      "items": {
+                                        "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                        "items": {
+                                          "description": "Maps a string key to a path within a volume.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the key to project.",
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "path"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "downwardAPI": {
+                                    "description": "downwardAPI information about the downwardAPI data to project",
+                                    "properties": {
+                                      "items": {
+                                        "description": "Items is a list of DownwardAPIVolume file",
+                                        "items": {
+                                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                          "properties": {
+                                            "fieldRef": {
+                                              "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "description": "Path of the field to select in the specified API version.",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "fieldPath"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "mode": {
+                                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                              "type": "string"
+                                            },
+                                            "resourceFieldRef": {
+                                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                              "properties": {
+                                                "containerName": {
+                                                  "description": "Container name: required for volumes, optional for env vars",
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "description": "Required: resource to select",
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "resource"
+                                              ],
+                                              "type": "object",
+                                              "x-kubernetes-map-type": "atomic"
+                                            }
+                                          },
+                                          "required": [
+                                            "path"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "podCertificate": {
+                                    "description": "Projects an auto-rotating credential bundle (private key and certificate\nchain) that the pod can use either as a TLS client or server.\n\nKubelet generates a private key and uses it to send a\nPodCertificateRequest to the named signer.  Once the signer approves the\nrequest and issues a certificate chain, Kubelet writes the key and\ncertificate chain to the pod filesystem.  The pod does not start until\ncertificates have been issued for each podCertificate projected volume\nsource in its spec.\n\nKubelet will begin trying to rotate the certificate at the time indicated\nby the signer using the PodCertificateRequest.Status.BeginRefreshAt\ntimestamp.\n\nKubelet can write a single file, indicated by the credentialBundlePath\nfield, or separate files, indicated by the keyPath and\ncertificateChainPath fields.\n\nThe credential bundle is a single file in PEM format.  The first PEM\nentry is the private key (in PKCS#8 format), and the remaining PEM\nentries are the certificate chain issued by the signer (typically,\nsigners will return their certificate chain in leaf-to-root order).\n\nPrefer using the credential bundle format, since your application code\ncan read it atomically.  If you use keyPath and certificateChainPath,\nyour application must make two separate file reads. If these coincide\nwith a certificate rotation, it is possible that the private key and leaf\ncertificate you read may not correspond to each other.  Your application\nwill need to check for this condition, and re-read until they are\nconsistent.\n\nThe named signer controls chooses the format of the certificate it\nissues; consult the signer implementation's documentation to learn how to\nuse the certificates it issues.",
+                                    "properties": {
+                                      "certificateChainPath": {
+                                        "description": "Write the certificate chain at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                                        "type": "string"
+                                      },
+                                      "credentialBundlePath": {
+                                        "description": "Write the credential bundle at this path in the projected volume.\n\nThe credential bundle is a single file that contains multiple PEM blocks.\nThe first PEM block is a PRIVATE KEY block, containing a PKCS#8 private\nkey.\n\nThe remaining blocks are CERTIFICATE blocks, containing the issued\ncertificate chain from the signer (leaf and any intermediates).\n\nUsing credentialBundlePath lets your Pod's application code make a single\natomic read that retrieves a consistent key and certificate chain.  If you\nproject them to separate files, your application code will need to\nadditionally check that the leaf certificate was issued to the key.",
+                                        "type": "string"
+                                      },
+                                      "keyPath": {
+                                        "description": "Write the key at this path in the projected volume.\n\nMost applications should use credentialBundlePath.  When using keyPath\nand certificateChainPath, your application needs to check that the key\nand leaf certificate are consistent, because it is possible to read the\nfiles mid-rotation.",
+                                        "type": "string"
+                                      },
+                                      "keyType": {
+                                        "description": "The type of keypair Kubelet will generate for the pod.\n\nValid values are \"RSA3072\", \"RSA4096\", \"ECDSAP256\", \"ECDSAP384\",\n\"ECDSAP521\", and \"ED25519\".",
+                                        "type": "string"
+                                      },
+                                      "maxExpirationSeconds": {
+                                        "description": "maxExpirationSeconds is the maximum lifetime permitted for the\ncertificate.\n\nKubelet copies this value verbatim into the PodCertificateRequests it\ngenerates for this projection.\n\nIf omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver\nwill reject values shorter than 3600 (1 hour).  The maximum allowable\nvalue is 7862400 (91 days).\n\nThe signer implementation is then free to issue a certificate with any\nlifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600\nseconds (1 hour).  This constraint is enforced by kube-apiserver.\n`kubernetes.io` signers will never issue certificates with a lifetime\nlonger than 24 hours.",
+                                        "format": "int32",
+                                        "type": "integer"
+                                      },
+                                      "signerName": {
+                                        "description": "Kubelet's generated CSRs will be addressed to this signer.",
+                                        "type": "string"
+                                      },
+                                      "userAnnotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "description": "userAnnotations allow pod authors to pass additional information to\nthe signer implementation.  Kubernetes does not restrict or validate this\nmetadata in any way.\n\nThese values are copied verbatim into the `spec.unverifiedUserAnnotations` field of\nthe PodCertificateRequest objects that Kubelet creates.\n\nEntries are subject to the same validation as object metadata annotations,\nwith the addition that all keys must be domain-prefixed. No restrictions\nare placed on values, except an overall size limitation on the entire field.\n\nSigners should document the keys and values they support. Signers should\ndeny requests that contain keys they do not recognize.",
+                                        "type": "object"
+                                      }
+                                    },
+                                    "required": [
+                                      "keyType",
+                                      "signerName"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "secret": {
+                                    "description": "secret information about the secret data to project",
+                                    "properties": {
+                                      "items": {
+                                        "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                        "items": {
+                                          "description": "Maps a string key to a path within a volume.",
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the key to project.",
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                              "format": "int32",
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key",
+                                            "path"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "optional field specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "serviceAccountToken": {
+                                    "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                    "properties": {
+                                      "audience": {
+                                        "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                        "type": "string"
+                                      },
+                                      "expirationSeconds": {
+                                        "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                        "format": "int64",
+                                        "type": "integer"
+                                      },
+                                      "path": {
+                                        "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "quobyte": {
+                          "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                          "properties": {
+                            "group": {
+                              "description": "group to map volume access to\nDefault is no group",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "registry": {
+                              "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                              "type": "string"
+                            },
+                            "tenant": {
+                              "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                              "type": "string"
+                            },
+                            "user": {
+                              "description": "user to map volume access to\nDefaults to serivceaccount user",
+                              "type": "string"
+                            },
+                            "volume": {
+                              "description": "volume is a string that references an already created Quobyte volume by name.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "registry",
+                            "volume"
+                          ],
+                          "type": "object"
+                        },
+                        "rbd": {
+                          "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                              "type": "string"
+                            },
+                            "image": {
+                              "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "string"
+                            },
+                            "keyring": {
+                              "default": "/etc/ceph/keyring",
+                              "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "string"
+                            },
+                            "monitors": {
+                              "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "pool": {
+                              "default": "rbd",
+                              "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "user": {
+                              "default": "admin",
+                              "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "image",
+                            "monitors"
+                          ],
+                          "type": "object"
+                        },
+                        "scaleIO": {
+                          "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                          "properties": {
+                            "fsType": {
+                              "default": "xfs",
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                              "type": "string"
+                            },
+                            "gateway": {
+                              "description": "gateway is the host address of the ScaleIO API Gateway.",
+                              "type": "string"
+                            },
+                            "protectionDomain": {
+                              "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "sslEnabled": {
+                              "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                              "type": "boolean"
+                            },
+                            "storageMode": {
+                              "default": "ThinProvisioned",
+                              "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                              "type": "string"
+                            },
+                            "storagePool": {
+                              "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                              "type": "string"
+                            },
+                            "system": {
+                              "description": "system is the name of the storage system as configured in ScaleIO.",
+                              "type": "string"
+                            },
+                            "volumeName": {
+                              "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "gateway",
+                            "secretRef",
+                            "system"
+                          ],
+                          "type": "object"
+                        },
+                        "secret": {
+                          "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                          "properties": {
+                            "defaultMode": {
+                              "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "format": "int32",
+                              "type": "integer"
+                            },
+                            "items": {
+                              "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                              "items": {
+                                "description": "Maps a string key to a path within a volume.",
+                                "properties": {
+                                  "key": {
+                                    "description": "key is the key to project.",
+                                    "type": "string"
+                                  },
+                                  "mode": {
+                                    "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                    "format": "int32",
+                                    "type": "integer"
+                                  },
+                                  "path": {
+                                    "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array",
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "optional": {
+                              "description": "optional field specify whether the Secret or its keys must be defined",
+                              "type": "boolean"
+                            },
+                            "secretName": {
+                              "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "storageos": {
+                          "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                              "type": "boolean"
+                            },
+                            "secretRef": {
+                              "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                              "properties": {
+                                "name": {
+                                  "default": "",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "volumeName": {
+                              "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                              "type": "string"
+                            },
+                            "volumeNamespace": {
+                              "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "vsphereVolume": {
+                          "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
+                          "properties": {
+                            "fsType": {
+                              "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                              "type": "string"
+                            },
+                            "storagePolicyID": {
+                              "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                              "type": "string"
+                            },
+                            "storagePolicyName": {
+                              "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                              "type": "string"
+                            },
+                            "volumePath": {
+                              "description": "volumePath is the path that identifies vSphere volume vmdk",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "volumePath"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "image",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "maintenance": {
+          "description": "Maintenance configuration behavior for upgrade operations",
+          "properties": {
+            "windows": {
+              "items": {
+                "properties": {
+                  "duration": {
+                    "description": "How long the window stays open (e.g., \"4h\", \"2h30m\")",
+                    "pattern": "^([0-9]+[smh])+$",
+                    "type": "string"
+                  },
+                  "start": {
+                    "description": "Cron expression (5-field): minute hour day-of-month month day-of-week",
+                    "minLength": 9,
+                    "type": "string"
+                  },
+                  "timezone": {
+                    "default": "UTC",
+                    "description": "IANA timezone (e.g., \"UTC\", \"Europe/Paris\")",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "duration",
+                  "start"
+                ],
+                "type": "object"
+              },
+              "minItems": 1,
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "nodeSelector": {
+          "description": "NodeSelector defines which nodes should be included in this upgrade.",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                },
+                "required": [
+                  "key",
+                  "operator"
+                ],
+                "type": "object"
+              },
+              "type": "array",
+              "x-kubernetes-list-type": "atomic"
+            },
+            "matchLabels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-map-type": "atomic"
+        },
+        "parallelism": {
+          "default": 1,
+          "description": "Parallelism is the number of nodes to upgrade concurrently in each batch.\nDefaults to 1 (sequential upgrades). Must be >= 1 and <= the number of matching nodes.",
+          "format": "int32",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "policy": {
+          "description": "Policy configures upgrade behavior",
+          "properties": {
+            "debug": {
+              "default": true,
+              "description": "Debug enables debug mode for the upgrade",
+              "type": "boolean"
+            },
+            "force": {
+              "default": false,
+              "description": "Force the upgrade (skip checks on etcd health and members)",
+              "type": "boolean"
+            },
+            "placement": {
+              "default": "soft",
+              "description": "Placement controls how strictly upgrade jobs avoid the target node\nhard: required avoidance (job will fail if can't avoid target node)\nsoft: preferred avoidance (job prefers to avoid but can run on target node)",
+              "enum": [
+                "hard",
+                "soft"
+              ],
+              "type": "string"
+            },
+            "rebootMode": {
+              "default": "default",
+              "description": "RebootMode select the reboot mode during upgrade",
+              "enum": [
+                "default",
+                "powercycle"
+              ],
+              "type": "string"
+            },
+            "stage": {
+              "default": false,
+              "description": "Stage the upgrade to perform it after a reboot",
+              "type": "boolean"
+            },
+            "timeout": {
+              "default": "30m",
+              "description": "Timeout for the per-node talosctl upgrade command",
+              "pattern": "^([0-9]+[smh])+$",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "talos": {
+          "description": "Talos specifies the talos configuration for upgrade operations",
+          "properties": {
+            "version": {
+              "description": "Version is the target Talos version to upgrade to (e.g., \"v1.11.0\")",
+              "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9\\-\\.]+)?$",
+              "type": "string"
+            }
+          },
+          "required": [
+            "version"
+          ],
+          "type": "object"
+        },
+        "talosctl": {
+          "description": "Talosctl specifies the talosctl configuration for upgrade operations",
+          "properties": {
+            "image": {
+              "description": "Image specifies the talosctl container image",
+              "properties": {
+                "pullPolicy": {
+                  "default": "IfNotPresent",
+                  "description": "PullPolicy describes a policy for if/when to pull a container image",
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "IfNotPresent"
+                  ],
+                  "type": "string"
+                },
+                "repository": {
+                  "default": "ghcr.io/siderolabs/talosctl",
+                  "description": "Repository is the talosctl container image repository",
+                  "type": "string"
+                },
+                "tag": {
+                  "description": "Tag is the talosctl container image tag\nIf not specified, defaults to the target version",
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "TalosUpgradeStatus defines the observed state of TalosUpgrade",
+      "properties": {
+        "completedAt": {
+          "description": "CompletedAt is the time the upgrade reached a terminal phase",
+          "format": "date-time",
+          "type": "string"
+        },
+        "completedNodes": {
+          "description": "CompletedNodes are nodes that have been successfully upgraded",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "conditions": {
+          "description": "Conditions report the upgrade's \"Progressing\" and \"Ready\" status.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "currentNode": {
+          "description": "CurrentNode is the node currently being upgraded (first node in batch for backwards compatibility)",
+          "type": "string"
+        },
+        "currentNodes": {
+          "description": "CurrentNodes is the list of nodes currently being upgraded in the active batch",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "failedNodes": {
+          "description": "FailedNodes are nodes that failed to upgrade",
+          "items": {
+            "description": "NodeUpgradeStatus tracks the upgrade status of individual nodes",
+            "properties": {
+              "jobName": {
+                "description": "JobName is the name of the job handling this node's upgrade",
+                "type": "string"
+              },
+              "lastError": {
+                "description": "LastError contains the last error message",
+                "type": "string"
+              },
+              "nodeName": {
+                "description": "NodeName is the name of the node",
+                "type": "string"
+              },
+              "retries": {
+                "description": "Retries is the number of times upgrade was attempted",
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "nodeName"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "history": {
+          "description": "History records past version transitions on this CR, newest first",
+          "items": {
+            "description": "TalosUpgradeHistoryEntry records a single completed Talos upgrade run",
+            "properties": {
+              "completedAt": {
+                "description": "CompletedAt is when the run reached its terminal phase",
+                "format": "date-time",
+                "type": "string"
+              },
+              "completedNodes": {
+                "description": "CompletedNodes are the nodes successfully upgraded during the run",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "failedNodes": {
+                "description": "FailedNodes are the nodes that failed during the run",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "phase": {
+                "description": "Phase is the terminal phase reached (Completed or Failed)",
+                "enum": [
+                  "Pending",
+                  "HealthChecking",
+                  "PreHook",
+                  "Draining",
+                  "Upgrading",
+                  "Rebooting",
+                  "PostHook",
+                  "Completed",
+                  "Failed",
+                  "MaintenanceWindow"
+                ],
+                "type": "string"
+              },
+              "startedAt": {
+                "description": "StartedAt is when the run began",
+                "format": "date-time",
+                "type": "string"
+              },
+              "toVersion": {
+                "description": "ToVersion is the spec-target Talos version at the time of completion",
+                "type": "string"
+              }
+            },
+            "required": [
+              "completedAt",
+              "phase",
+              "startedAt",
+              "toVersion"
+            ],
+            "type": "object"
+          },
+          "maxItems": 10,
+          "type": "array"
+        },
+        "lastUpdated": {
+          "description": "LastUpdated timestamp of last status update",
+          "format": "date-time",
+          "type": "string"
+        },
+        "message": {
+          "description": "Message provides details about the current state",
+          "type": "string"
+        },
+        "nextMaintenanceWindow": {
+          "description": "NextMaintenanceWindow reflect the next time a maintenance can happen",
+          "format": "date-time",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration reflects the generation of the most recently observed spec",
+          "format": "int64",
+          "type": "integer"
+        },
+        "phase": {
+          "description": "Phase represents the current phase of the upgrade",
+          "enum": [
+            "Pending",
+            "HealthChecking",
+            "PreHook",
+            "Draining",
+            "Upgrading",
+            "Rebooting",
+            "PostHook",
+            "Completed",
+            "Failed",
+            "MaintenanceWindow"
+          ],
+          "type": "string"
+        },
+        "postHookIndex": {
+          "description": "PostHookIndex is the index of the next post-hook to run.",
+          "type": "integer"
+        },
+        "preHookFailed": {
+          "description": "PreHookFailed records that a pre-hook failed during this run, so the\nterminal phase ends up Failed even after post-hooks (cleanup) succeed.",
+          "type": "boolean"
+        },
+        "preHookIndex": {
+          "description": "PreHookIndex is the index of the next pre-hook to run.\nEquals len(spec.hooks.pre) once all pre-hooks are done.",
+          "type": "integer"
+        },
+        "startedAt": {
+          "description": "StartedAt is the time the current upgrade run began",
+          "format": "date-time",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

- Add `crds/tuppr.sh` CRD source config targeting tuppr v0.1.35 from home-operations with Renovate auto-bump support
- Generate JSON schemas for `KubernetesUpgrade` and `TalosUpgrade` v1alpha1 CRDs
- Register both schemas in the schema catalog under `tuppr.home-operations.com`