### PR TITLE
feat(crd): add agent gateway CRD schemas

### DIFF
--- a/crds/agent-gateway.sh
+++ b/crds/agent-gateway.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (C) Nicolas Lamirault <nicolas.lamirault@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+export choice=individual
+export FILES=(
+  "agentgateway.dev_agentgatewaybackends.yaml"
+  "agentgateway.dev_agentgatewayparameters.yaml"
+  "agentgateway.dev_agentgatewaypolicies.yaml"
+)
+
+# renovate: datasource=github-tags depName=agentgateway/agentgateway
+export VERSION=1.2.1
+
+function generate_url {
+  local crd_file=$1
+  echo "https://raw.githubusercontent.com/agentgateway/agentgateway/refs/tags/v${VERSION}/controller/install/helm/agentgateway-crds/templates/${crd_file}"
+}

--- a/public/data/catalog.json
+++ b/public/data/catalog.json
@@ -474,6 +474,26 @@
         "slug": "admissionregistration.api.k8s.io/v1/WebhookClientConfig"
       }
     ],
+    "agentgateway.dev": [
+      {
+        "kind": "agentgatewaybackend",
+        "version": "v1alpha1",
+        "file": "agentgateway.dev/agentgatewaybackend_v1alpha1.json",
+        "slug": "agentgateway.dev/v1alpha1/agentgatewaybackend"
+      },
+      {
+        "kind": "agentgatewayparameters",
+        "version": "v1alpha1",
+        "file": "agentgateway.dev/agentgatewayparameters_v1alpha1.json",
+        "slug": "agentgateway.dev/v1alpha1/agentgatewayparameters"
+      },
+      {
+        "kind": "agentgatewaypolicy",
+        "version": "v1alpha1",
+        "file": "agentgateway.dev/agentgatewaypolicy_v1alpha1.json",
+        "slug": "agentgateway.dev/v1alpha1/agentgatewaypolicy"
+      }
+    ],
     "aiplatform.cnrm.cloud.google.com": [
       {
         "kind": "aiplatformmodel",

--- a/schemas/agentgateway.dev/agentgatewaybackend_v1alpha1.json
+++ b/schemas/agentgateway.dev/agentgatewaybackend_v1alpha1.json
@@ -1,0 +1,9226 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of AgentgatewayBackend.",
+      "properties": {
+        "ai": {
+          "description": "ai represents a LLM backend.",
+          "properties": {
+            "groups": {
+              "description": "`groups` specifies a list of groups in priority order where each group\ndefines a set of LLM providers. The priority determines the priority of\nthe backend endpoints chosen.\nNote: provider names must be unique across all providers in all priority\ngroups. Backend policies may target a specific provider by name using\n`targetRefs[].sectionName`.\n\nExample configuration with two priority groups:\n\n\tgroups:\n\t- providers:\n\t  - azureopenai:\n\t      deploymentName: gpt-4o-mini\n\t      apiVersion: 2024-02-15-preview\n\t      endpoint: ai-gateway.openai.azure.com\n\t- providers:\n\t  - azureopenai:\n\t      deploymentName: gpt-4o-mini-2\n\t      apiVersion: 2024-02-15-preview\n\t      endpoint: ai-gateway-2.openai.azure.com\n\t     policies:\n\t       auth:\n\t         secretRef:\n\t           name: azure-secret",
+              "items": {
+                "properties": {
+                  "providers": {
+                    "description": "providers specifies a list of LLM providers within this group. Each provider is treated equally in terms of priority,\nwith automatic weighting based on health.",
+                    "items": {
+                      "properties": {
+                        "anthropic": {
+                          "description": "Anthropic provider",
+                          "properties": {
+                            "model": {
+                              "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "azure": {
+                          "description": "Azure provider with resource-based configuration.\nSupports both Azure OpenAI and Azure AI Foundry resource types.",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "The version of the Azure OpenAI API to use.\nIf unset, defaults to `v1`.",
+                              "maxLength": 64,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "model": {
+                              "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "projectName": {
+                              "description": "The Foundry project name, required when `resourceType` is `Foundry`.\nUsed to construct paths: /api/projects/{projectName}/openai/v1/...",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "resourceName": {
+                              "description": "The Azure resource name used to construct the endpoint host.\nFor OpenAI: {resourceName}.openai.azure.com\nFor Foundry: {resourceName}-resource.services.ai.azure.com",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "resourceType": {
+                              "description": "The type of Azure endpoint. Determines the host suffix.",
+                              "enum": [
+                                "OpenAI",
+                                "Foundry"
+                              ],
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "resourceName",
+                            "resourceType"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "projectName is required when resourceType is Foundry",
+                              "rule": "self.resourceType != 'Foundry' || has(self.projectName)"
+                            }
+                          ]
+                        },
+                        "azureopenai": {
+                          "description": "Azure OpenAI provider",
+                          "properties": {
+                            "apiVersion": {
+                              "description": "The version of the Azure OpenAI API to use.\nFor more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/foundry/openai/reference).\nIf unset, defaults to `v1`.",
+                              "maxLength": 64,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "deploymentName": {
+                              "description": "The name of the Azure OpenAI model deployment to use.\nFor more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).\nThis is required if `apiVersion` is not `v1`. For `v1`, the model can be\nset in the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "endpoint": {
+                              "description": "The endpoint for the Azure OpenAI API to use, such as `my-endpoint.openai.azure.com`.\nIf the scheme is included, it is stripped.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "endpoint"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "deploymentName is required for this apiVersion",
+                              "rule": "!has(self.apiVersion) || self.apiVersion == 'v1' ? true : has(self.deploymentName)"
+                            }
+                          ]
+                        },
+                        "bedrock": {
+                          "description": "Bedrock provider",
+                          "properties": {
+                            "guardrail": {
+                              "description": "`guardrail` configures the Guardrail policy to use for the backend. See\n<https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html>.\nIf not specified, the AWS Guardrail policy will not be used.",
+                              "properties": {
+                                "identifier": {
+                                  "description": "GuardrailIdentifier is the identifier of the Guardrail policy to use for the backend.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "description": "GuardrailVersion is the version of the Guardrail policy to use for the backend.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "identifier",
+                                "version"
+                              ],
+                              "type": "object"
+                            },
+                            "model": {
+                              "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "region": {
+                              "default": "us-east-1",
+                              "description": "Region is the AWS region to use for the backend.\nDefaults to `us-east-1` if not specified.",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9-]+$",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "gemini": {
+                          "description": "Gemini provider",
+                          "properties": {
+                            "model": {
+                              "description": "Optional: Override the model name, such as `gemini-2.5-pro`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "host": {
+                          "description": "Host specifies the hostname to send the requests to.\nIf not specified, the default hostname for the provider is used.",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the provider. Policies can target this provider by name.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "openai": {
+                          "description": "OpenAI provider",
+                          "properties": {
+                            "model": {
+                              "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "path": {
+                          "description": "Path specifies the URL path to use for the LLM provider API requests.\nThis is useful when you need to route requests to a different API endpoint while maintaining\ncompatibility with the original provider's API structure.\nIf not specified, the default path for the provider is used.",
+                          "maxLength": 1024,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "pathPrefix": {
+                          "description": "PathPrefix overrides the default base path prefix (e.g. \"/v1\") for upstream requests.\nPath translation for cross-format requests still applies using this prefix.\nOnly supported for OpenAI and Anthropic providers.",
+                          "maxLength": 1024,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "policies": {
+                          "description": "`policies` controls policies for communicating with this backend.\nPolicies may also be set in `AgentgatewayPolicy`, or in the top-level\n`AgentgatewayBackend`. Policies are merged on a field-level basis, with\norder: `AgentgatewayPolicy` < `AgentgatewayBackend` < `AgentgatewayBackend`\nLLM provider (this field).",
+                          "properties": {
+                            "ai": {
+                              "description": "`ai` specifies settings for AI workloads. This is only applicable when\nconnecting to a `Backend` of type `ai`.",
+                              "properties": {
+                                "defaults": {
+                                  "description": "Provide defaults to merge with user input fields. If the field is already set, the field in the request is used.",
+                                  "items": {
+                                    "description": "FieldDefault provides default values for specific fields in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                                    "properties": {
+                                      "field": {
+                                        "allOf": [
+                                          {
+                                            "minLength": 1
+                                          },
+                                          {
+                                            "minLength": 1
+                                          }
+                                        ],
+                                        "description": "The name of the field.",
+                                        "maxLength": 256,
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "The field default value, which can be any JSON Data Type.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "required": [
+                                      "field",
+                                      "value"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 64,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "modelAliases": {
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  },
+                                  "description": "ModelAliases maps friendly model names to actual provider model names.\nExample: `{\"fast\": \"gpt-3.5-turbo\", \"smart\": \"gpt-4-turbo\"}`.\nNote: This field is only applicable when using the agentgateway data plane.",
+                                  "maxProperties": 64,
+                                  "type": "object"
+                                },
+                                "overrides": {
+                                  "description": "Provide overrides to merge with user input fields. If the field is already set, the field will be overwritten.",
+                                  "items": {
+                                    "description": "FieldDefault provides default values for specific fields in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                                    "properties": {
+                                      "field": {
+                                        "allOf": [
+                                          {
+                                            "minLength": 1
+                                          },
+                                          {
+                                            "minLength": 1
+                                          }
+                                        ],
+                                        "description": "The name of the field.",
+                                        "maxLength": 256,
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "The field default value, which can be any JSON Data Type.",
+                                        "x-kubernetes-preserve-unknown-fields": true
+                                      }
+                                    },
+                                    "required": [
+                                      "field",
+                                      "value"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 64,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "prompt": {
+                                  "description": "Enrich requests sent to the LLM provider by appending and prepending system prompts. This can be configured only for\nLLM providers that use the `CHAT` or `CHAT_STREAMING` API route type.",
+                                  "properties": {
+                                    "append": {
+                                      "description": "A list of messages to be appended to the prompt sent by the client.",
+                                      "items": {
+                                        "description": "An entry for a message to prepend or append to each prompt.",
+                                        "properties": {
+                                          "content": {
+                                            "description": "String content of the message.",
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "content",
+                                          "role"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    },
+                                    "prepend": {
+                                      "description": "A list of messages to be prepended to the prompt sent by the client.",
+                                      "items": {
+                                        "description": "An entry for a message to prepend or append to each prompt.",
+                                        "properties": {
+                                          "content": {
+                                            "description": "String content of the message.",
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "content",
+                                          "role"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "promptCaching": {
+                                  "description": "`promptCaching` enables automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
+                                  "properties": {
+                                    "cacheMessageOffset": {
+                                      "default": 0,
+                                      "description": "CacheMessageOffset shifts the message cache point further back in the\nconversation. 0 (default) places it at the second-to-last message.\nHigher values move it N additional messages towards the start, clamped\nto bounds.",
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "cacheMessages": {
+                                      "default": true,
+                                      "description": "CacheMessages enables caching for conversation messages.\nCaches all messages in the conversation for cost savings.",
+                                      "type": "boolean"
+                                    },
+                                    "cacheSystem": {
+                                      "default": true,
+                                      "description": "CacheSystem enables caching for system prompts.\nInserts a cache point after all system messages.",
+                                      "type": "boolean"
+                                    },
+                                    "cacheTools": {
+                                      "default": false,
+                                      "description": "CacheTools enables caching for tool definitions.\nInserts a cache point after all tool specifications.",
+                                      "type": "boolean"
+                                    },
+                                    "minTokens": {
+                                      "default": 1024,
+                                      "description": "MinTokens specifies the minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count × 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "promptGuard": {
+                                  "description": "`promptGuard` enables adding guardrails to LLM requests and responses.",
+                                  "properties": {
+                                    "request": {
+                                      "description": "Prompt guards to apply to requests sent by the client.",
+                                      "items": {
+                                        "description": "PromptguardRequest defines the prompt guards to apply to requests sent by the client.",
+                                        "properties": {
+                                          "bedrockGuardrails": {
+                                            "description": "`bedrockGuardrails` configures AWS Bedrock Guardrails for prompt\nguarding.",
+                                            "properties": {
+                                              "identifier": {
+                                                "description": "GuardrailIdentifier is the identifier of the Guardrail policy to use for the backend.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "policies controls policies for communicating with AWS Bedrock Guardrails.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "secretRef"
+                                                        ],
+                                                        "type": "object"
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Details for managed identity authentication",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "key": {
+                                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                                        "properties": {
+                                                          "name": {
+                                                            "default": "",
+                                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "http": {
+                                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tcp": {
+                                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tls": {
+                                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "X25519",
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "region": {
+                                                "description": "Region is the AWS region where the guardrail is deployed (for example,\n`us-west-2`).",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "description": "GuardrailVersion is the version of the Guardrail policy to use for the backend.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "identifier",
+                                              "region",
+                                              "version"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "googleModelArmor": {
+                                            "description": "`googleModelArmor` configures Google Model Armor for prompt guarding.",
+                                            "properties": {
+                                              "location": {
+                                                "default": "us-central1",
+                                                "description": "Location is the Google Cloud location (for example, `us-central1`).\nDefaults to `us-central1` if not specified.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "policies controls policies for communicating with Google Model Armor.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "secretRef"
+                                                        ],
+                                                        "type": "object"
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Details for managed identity authentication",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "key": {
+                                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                                        "properties": {
+                                                          "name": {
+                                                            "default": "",
+                                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "http": {
+                                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tcp": {
+                                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tls": {
+                                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "X25519",
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "projectId": {
+                                                "description": "ProjectID is the Google Cloud project ID.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "templateId": {
+                                                "description": "TemplateID is the template ID for Google Model Armor.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "projectId",
+                                              "templateId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "openAIModeration": {
+                                            "description": "`openAIModeration` passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
+                                            "properties": {
+                                              "model": {
+                                                "description": "`model` specifies the moderation model to use. For example,\n`omni-moderation`.",
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "policies controls policies for communicating with OpenAI.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "secretRef"
+                                                        ],
+                                                        "type": "object"
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Details for managed identity authentication",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "key": {
+                                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                                        "properties": {
+                                                          "name": {
+                                                            "default": "",
+                                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "http": {
+                                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tcp": {
+                                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tls": {
+                                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "X25519",
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "regex": {
+                                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                                            "properties": {
+                                              "action": {
+                                                "default": "Mask",
+                                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                                "enum": [
+                                                  "Mask",
+                                                  "Reject"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "builtins": {
+                                                "description": "A list of built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                                "items": {
+                                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                                  "enum": [
+                                                    "Ssn",
+                                                    "CreditCard",
+                                                    "PhoneNumber",
+                                                    "Email",
+                                                    "CaSin"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matches": {
+                                                "description": "A list of regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                                "items": {
+                                                  "maxLength": 1024,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "response": {
+                                            "description": "A custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                            "properties": {
+                                              "message": {
+                                                "default": "The request was rejected due to inappropriate content",
+                                                "description": "A custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                                "type": "string"
+                                              },
+                                              "statusCode": {
+                                                "default": 403,
+                                                "description": "The status code to return to the client. Defaults to 403.",
+                                                "format": "int32",
+                                                "maximum": 599,
+                                                "minimum": 200,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "at least one of the fields in [message statusCode] must be set",
+                                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                                              }
+                                            ]
+                                          },
+                                          "webhook": {
+                                            "description": "Configure a webhook to forward requests to for prompt guarding.",
+                                            "properties": {
+                                              "backendRef": {
+                                                "description": "backendRef references the webhook server to reach.\n\nSupported types: Service and Backend.",
+                                                "properties": {
+                                                  "group": {
+                                                    "default": "",
+                                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                    "maxLength": 253,
+                                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "default": "Service",
+                                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                    "maxLength": 63,
+                                                    "minLength": 1,
+                                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name is the name of the referent.",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                    "maxLength": 63,
+                                                    "minLength": 1,
+                                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                    "format": "int32",
+                                                    "maximum": 65535,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "Must have port for Service reference",
+                                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                  }
+                                                ]
+                                              },
+                                              "forwardHeaderMatches": {
+                                                "description": "ForwardHeaderMatches defines a list of HTTP header matches that will be\nused to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                                "items": {
+                                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                                  "properties": {
+                                                    "name": {
+                                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                                      "maxLength": 256,
+                                                      "minLength": 1,
+                                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                      "type": "string"
+                                                    },
+                                                    "type": {
+                                                      "default": "Exact",
+                                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                                      "enum": [
+                                                        "Exact",
+                                                        "RegularExpression"
+                                                      ],
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                                      "maxLength": 4096,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "required": [
+                                              "backendRef"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
+                                            "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "maxItems": 8,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "response": {
+                                      "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                                      "items": {
+                                        "description": "PromptguardResponse configures the response that the prompt guard applies to responses returned by the LLM provider.",
+                                        "properties": {
+                                          "bedrockGuardrails": {
+                                            "description": "`bedrockGuardrails` configures AWS Bedrock Guardrails for prompt\nguarding.",
+                                            "properties": {
+                                              "identifier": {
+                                                "description": "GuardrailIdentifier is the identifier of the Guardrail policy to use for the backend.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "policies controls policies for communicating with AWS Bedrock Guardrails.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "secretRef"
+                                                        ],
+                                                        "type": "object"
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Details for managed identity authentication",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "key": {
+                                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                                        "properties": {
+                                                          "name": {
+                                                            "default": "",
+                                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "http": {
+                                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tcp": {
+                                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tls": {
+                                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "X25519",
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "region": {
+                                                "description": "Region is the AWS region where the guardrail is deployed (for example,\n`us-west-2`).",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "version": {
+                                                "description": "GuardrailVersion is the version of the Guardrail policy to use for the backend.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "identifier",
+                                              "region",
+                                              "version"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "googleModelArmor": {
+                                            "description": "`googleModelArmor` configures Google Model Armor for prompt guarding.",
+                                            "properties": {
+                                              "location": {
+                                                "default": "us-central1",
+                                                "description": "Location is the Google Cloud location (for example, `us-central1`).\nDefaults to `us-central1` if not specified.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "policies": {
+                                                "description": "policies controls policies for communicating with Google Model Armor.",
+                                                "properties": {
+                                                  "auth": {
+                                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                                    "properties": {
+                                                      "aws": {
+                                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "secretRef"
+                                                        ],
+                                                        "type": "object"
+                                                      },
+                                                      "azure": {
+                                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                                        "properties": {
+                                                          "managedIdentity": {
+                                                            "description": "Details for managed identity authentication",
+                                                            "properties": {
+                                                              "clientId": {
+                                                                "type": "string"
+                                                              },
+                                                              "objectId": {
+                                                                "type": "string"
+                                                              },
+                                                              "resourceId": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "clientId",
+                                                              "objectId",
+                                                              "resourceId"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "gcp": {
+                                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                                        "properties": {
+                                                          "audience": {
+                                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                                            "maxLength": 256,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "secretRef": {
+                                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                                            "properties": {
+                                                              "name": {
+                                                                "default": "",
+                                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object",
+                                                            "x-kubernetes-map-type": "atomic"
+                                                          },
+                                                          "type": {
+                                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                                            "enum": [
+                                                              "AccessToken",
+                                                              "IdToken"
+                                                            ],
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "audience is only valid with IdToken",
+                                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "key": {
+                                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                                        "maxLength": 2048,
+                                                        "type": "string"
+                                                      },
+                                                      "location": {
+                                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                                        "properties": {
+                                                          "cookie": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "header": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                                "type": "string"
+                                                              },
+                                                              "prefix": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          },
+                                                          "queryParameter": {
+                                                            "properties": {
+                                                              "name": {
+                                                                "maxLength": 256,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "name"
+                                                            ],
+                                                            "type": "object"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "passthrough": {
+                                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                                        "type": "object"
+                                                      },
+                                                      "secretRef": {
+                                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                                        "properties": {
+                                                          "name": {
+                                                            "default": "",
+                                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "x-kubernetes-map-type": "atomic"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "location may only be set for key or passthrough auth",
+                                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                                      },
+                                                      {
+                                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "http": {
+                                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                                    "properties": {
+                                                      "requestTimeout": {
+                                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "requestTimeout must be at least 1ms",
+                                                            "rule": "duration(self) >= duration('1ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "version": {
+                                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                                        "enum": [
+                                                          "HTTP1",
+                                                          "HTTP2"
+                                                        ],
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tcp": {
+                                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                                    "properties": {
+                                                      "connectTimeout": {
+                                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                                        "type": "string",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "invalid duration value",
+                                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                          },
+                                                          {
+                                                            "message": "connectTimeout must be at least 100ms",
+                                                            "rule": "duration(self) >= duration('100ms')"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "keepalive": {
+                                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                                        "properties": {
+                                                          "interval": {
+                                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "interval must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "retries": {
+                                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                                            "format": "int32",
+                                                            "maximum": 64,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          },
+                                                          "time": {
+                                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                                            "type": "string",
+                                                            "x-kubernetes-validations": [
+                                                              {
+                                                                "message": "invalid duration value",
+                                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                                              },
+                                                              {
+                                                                "message": "time must be at least 1 second",
+                                                                "rule": "duration(self) >= duration('1s')"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "tls": {
+                                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                                    "properties": {
+                                                      "alpnProtocols": {
+                                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                                        "items": {
+                                                          "maxLength": 64,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      },
+                                                      "caCertificateRefs": {
+                                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "insecureSkipVerify": {
+                                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                                        "enum": [
+                                                          "All",
+                                                          "Hostname"
+                                                        ],
+                                                        "type": "string"
+                                                      },
+                                                      "keyExchangeGroups": {
+                                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                                        "items": {
+                                                          "enum": [
+                                                            "X25519",
+                                                            "P-256",
+                                                            "P-384",
+                                                            "X25519_MLKEM768"
+                                                          ],
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      "mtlsCertificateRef": {
+                                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                                        "items": {
+                                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                                          "properties": {
+                                                            "name": {
+                                                              "default": "",
+                                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object",
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "maxItems": 1,
+                                                        "type": "array",
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      },
+                                                      "sni": {
+                                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                                        "maxLength": 253,
+                                                        "minLength": 1,
+                                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                        "type": "string"
+                                                      },
+                                                      "verifySubjectAltNames": {
+                                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                                        "items": {
+                                                          "maxLength": 256,
+                                                          "minLength": 1,
+                                                          "type": "string"
+                                                        },
+                                                        "maxItems": 16,
+                                                        "minItems": 1,
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "x-kubernetes-validations": [
+                                                      {
+                                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                                      },
+                                                      {
+                                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                                      },
+                                                      {
+                                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "tunnel": {
+                                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                                    "properties": {
+                                                      "backendRef": {
+                                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                                        "properties": {
+                                                          "group": {
+                                                            "default": "",
+                                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                            "maxLength": 253,
+                                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                            "type": "string"
+                                                          },
+                                                          "kind": {
+                                                            "default": "Service",
+                                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "name": {
+                                                            "description": "Name is the name of the referent.",
+                                                            "maxLength": 253,
+                                                            "minLength": 1,
+                                                            "type": "string"
+                                                          },
+                                                          "namespace": {
+                                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                            "maxLength": 63,
+                                                            "minLength": 1,
+                                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                            "format": "int32",
+                                                            "maximum": 65535,
+                                                            "minimum": 1,
+                                                            "type": "integer"
+                                                          }
+                                                        },
+                                                        "required": [
+                                                          "name"
+                                                        ],
+                                                        "type": "object",
+                                                        "x-kubernetes-validations": [
+                                                          {
+                                                            "message": "Must have port for Service reference",
+                                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "backendRef"
+                                                    ],
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "projectId": {
+                                                "description": "ProjectID is the Google Cloud project ID.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              },
+                                              "templateId": {
+                                                "description": "TemplateID is the template ID for Google Model Armor.",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "projectId",
+                                              "templateId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "regex": {
+                                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                                            "properties": {
+                                              "action": {
+                                                "default": "Mask",
+                                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                                "enum": [
+                                                  "Mask",
+                                                  "Reject"
+                                                ],
+                                                "type": "string"
+                                              },
+                                              "builtins": {
+                                                "description": "A list of built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                                "items": {
+                                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                                  "enum": [
+                                                    "Ssn",
+                                                    "CreditCard",
+                                                    "PhoneNumber",
+                                                    "Email",
+                                                    "CaSin"
+                                                  ],
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matches": {
+                                                "description": "A list of regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                                "items": {
+                                                  "maxLength": 1024,
+                                                  "minLength": 1,
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "response": {
+                                            "description": "A custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
+                                            "properties": {
+                                              "message": {
+                                                "default": "The request was rejected due to inappropriate content",
+                                                "description": "A custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                                "type": "string"
+                                              },
+                                              "statusCode": {
+                                                "default": 403,
+                                                "description": "The status code to return to the client. Defaults to 403.",
+                                                "format": "int32",
+                                                "maximum": 599,
+                                                "minimum": 200,
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "at least one of the fields in [message statusCode] must be set",
+                                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                                              }
+                                            ]
+                                          },
+                                          "webhook": {
+                                            "description": "Configure a webhook to forward responses to for prompt guarding.",
+                                            "properties": {
+                                              "backendRef": {
+                                                "description": "backendRef references the webhook server to reach.\n\nSupported types: Service and Backend.",
+                                                "properties": {
+                                                  "group": {
+                                                    "default": "",
+                                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                                    "maxLength": 253,
+                                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "default": "Service",
+                                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                                    "maxLength": 63,
+                                                    "minLength": 1,
+                                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name is the name of the referent.",
+                                                    "maxLength": 253,
+                                                    "minLength": 1,
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                                    "maxLength": 63,
+                                                    "minLength": 1,
+                                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                                    "format": "int32",
+                                                    "maximum": 65535,
+                                                    "minimum": 1,
+                                                    "type": "integer"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "name"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                  {
+                                                    "message": "Must have port for Service reference",
+                                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                                  }
+                                                ]
+                                              },
+                                              "forwardHeaderMatches": {
+                                                "description": "ForwardHeaderMatches defines a list of HTTP header matches that will be\nused to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                                "items": {
+                                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                                  "properties": {
+                                                    "name": {
+                                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                                      "maxLength": 256,
+                                                      "minLength": 1,
+                                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                      "type": "string"
+                                                    },
+                                                    "type": {
+                                                      "default": "Exact",
+                                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                                      "enum": [
+                                                        "Exact",
+                                                        "RegularExpression"
+                                                      ],
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                                      "maxLength": 4096,
+                                                      "minLength": 1,
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "value"
+                                                  ],
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "required": [
+                                              "backendRef"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
+                                            "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "maxItems": 8,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "at least one of the fields in [request response] must be set",
+                                      "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                                    }
+                                  ]
+                                },
+                                "routes": {
+                                  "additionalProperties": {
+                                    "description": "RouteType specifies how the AI gateway should process incoming requests\nbased on the URL path and the API format expected.",
+                                    "enum": [
+                                      "Completions",
+                                      "Messages",
+                                      "Models",
+                                      "Passthrough",
+                                      "Detect",
+                                      "Responses",
+                                      "AnthropicTokenCount",
+                                      "Embeddings",
+                                      "Realtime"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "description": "`routes` defines how to identify the type of traffic to handle.\nThe keys are URL path suffixes matched using ends-with comparison, for\nexample `\"/v1/chat/completions\"`.\nThe special `*` wildcard matches any path.\nIf not specified, all traffic defaults to `completions` type.",
+                                  "type": "object"
+                                },
+                                "transformations": {
+                                  "description": "Provide CEL transformations to compute and set fields in the request body.\nThe expression result overwrites any existing value for that field.\nThis has a higher priority than `overrides` if both are set for the same\nkey.",
+                                  "items": {
+                                    "description": "FieldTransformation maps a request JSON field to a CEL expression string.\nThe expression is evaluated against the current request body and its result\nis assigned to the configured field.",
+                                    "properties": {
+                                      "expression": {
+                                        "description": "CEL expression used to compute the field value.",
+                                        "maxLength": 16384,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "field": {
+                                        "allOf": [
+                                          {
+                                            "minLength": 1
+                                          },
+                                          {
+                                            "minLength": 1
+                                          }
+                                        ],
+                                        "description": "The name of the field to set.",
+                                        "maxLength": 256,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "expression",
+                                      "field"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "maxItems": 64,
+                                  "minItems": 1,
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
+                                  "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
+                                }
+                              ]
+                            },
+                            "auth": {
+                              "description": "`auth` defines settings for managing authentication to the backend.",
+                              "properties": {
+                                "aws": {
+                                  "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                  "properties": {
+                                    "secretRef": {
+                                      "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic"
+                                    }
+                                  },
+                                  "required": [
+                                    "secretRef"
+                                  ],
+                                  "type": "object"
+                                },
+                                "azure": {
+                                  "description": "Azure specifies an Azure authentication method for the backend.",
+                                  "properties": {
+                                    "managedIdentity": {
+                                      "description": "Details for managed identity authentication",
+                                      "properties": {
+                                        "clientId": {
+                                          "type": "string"
+                                        },
+                                        "objectId": {
+                                          "type": "string"
+                                        },
+                                        "resourceId": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "clientId",
+                                        "objectId",
+                                        "resourceId"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "secretRef": {
+                                      "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "gcp": {
+                                  "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                  "properties": {
+                                    "audience": {
+                                      "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                      "properties": {
+                                        "name": {
+                                          "default": "",
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "type": {
+                                      "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                      "enum": [
+                                        "AccessToken",
+                                        "IdToken"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "audience is only valid with IdToken",
+                                      "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                    }
+                                  ]
+                                },
+                                "key": {
+                                  "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                  "maxLength": 2048,
+                                  "type": "string"
+                                },
+                                "location": {
+                                  "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                  "properties": {
+                                    "cookie": {
+                                      "properties": {
+                                        "name": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "header": {
+                                      "properties": {
+                                        "name": {
+                                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                          "type": "string"
+                                        },
+                                        "prefix": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "queryParameter": {
+                                      "properties": {
+                                        "name": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                    }
+                                  ]
+                                },
+                                "passthrough": {
+                                  "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                  "type": "object"
+                                },
+                                "secretRef": {
+                                  "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                  "properties": {
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "location may only be set for key or passthrough auth",
+                                  "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                },
+                                {
+                                  "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                }
+                              ]
+                            },
+                            "health": {
+                              "description": "health defines settings for passive and active health checking.",
+                              "properties": {
+                                "eviction": {
+                                  "description": "Eviction defines settings for evicting unhealthy backends.",
+                                  "properties": {
+                                    "consecutiveFailures": {
+                                      "description": "ConsecutiveFailures is the number of consecutive unhealthy responses required before the backend is evicted.\nFor example, a value of 5 means the backend must receive 5 unhealthy responses in a row before being evicted.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response can trigger eviction.",
+                                      "format": "int32",
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "duration": {
+                                      "default": "3s",
+                                      "description": "Duration specifies the base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "invalid duration value",
+                                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                        },
+                                        {
+                                          "message": "evictionDuration must be at least 1 second",
+                                          "rule": "duration(self) >= duration('1s')"
+                                        }
+                                      ]
+                                    },
+                                    "healthThreshold": {
+                                      "description": "HealthThreshold is the EWMA (exponentially-weighted moving average) health score threshold, expressed as 0–100.\nWhen set, a backend is only evicted if its computed health drops below this value after an unhealthy response.\nFor example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.\nUnlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average\nso a single success in a stream of failures can delay eviction.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response triggers eviction.",
+                                      "format": "int32",
+                                      "maximum": 100,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    },
+                                    "restoreHealth": {
+                                      "description": "RestoreHealth is the health score (0–100) assigned to a backend when it returns from eviction.\nFor gradual recovery, set below 100; for full recovery immediately, set 100.\nIf unset, the backend resumes with the health it had when evicted.",
+                                      "format": "int32",
+                                      "maximum": 100,
+                                      "minimum": 0,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                "unhealthyCondition": {
+                                  "description": "UnhealthyCondition is a CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "http": {
+                              "description": "http defines settings for managing HTTP requests to the backend.",
+                              "properties": {
+                                "requestTimeout": {
+                                  "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "invalid duration value",
+                                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                    },
+                                    {
+                                      "message": "requestTimeout must be at least 1ms",
+                                      "rule": "duration(self) >= duration('1ms')"
+                                    }
+                                  ]
+                                },
+                                "version": {
+                                  "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                  "enum": [
+                                    "HTTP1",
+                                    "HTTP2"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "tcp": {
+                              "description": "tcp defines settings for managing TCP connections to the backend.",
+                              "properties": {
+                                "connectTimeout": {
+                                  "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "invalid duration value",
+                                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                    },
+                                    {
+                                      "message": "connectTimeout must be at least 100ms",
+                                      "rule": "duration(self) >= duration('100ms')"
+                                    }
+                                  ]
+                                },
+                                "keepalive": {
+                                  "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                  "properties": {
+                                    "interval": {
+                                      "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "invalid duration value",
+                                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                        },
+                                        {
+                                          "message": "interval must be at least 1 second",
+                                          "rule": "duration(self) >= duration('1s')"
+                                        }
+                                      ]
+                                    },
+                                    "retries": {
+                                      "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                      "format": "int32",
+                                      "maximum": 64,
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    },
+                                    "time": {
+                                      "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "invalid duration value",
+                                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                        },
+                                        {
+                                          "message": "time must be at least 1 second",
+                                          "rule": "duration(self) >= duration('1s')"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "tls": {
+                              "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                              "properties": {
+                                "alpnProtocols": {
+                                  "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                  "items": {
+                                    "maxLength": 64,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "maxItems": 16,
+                                  "minItems": 1,
+                                  "type": "array"
+                                },
+                                "caCertificateRefs": {
+                                  "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                  "items": {
+                                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "maxItems": 1,
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "insecureSkipVerify": {
+                                  "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                  "enum": [
+                                    "All",
+                                    "Hostname"
+                                  ],
+                                  "type": "string"
+                                },
+                                "keyExchangeGroups": {
+                                  "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                  "items": {
+                                    "enum": [
+                                      "X25519",
+                                      "P-256",
+                                      "P-384",
+                                      "X25519_MLKEM768"
+                                    ],
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "mtlsCertificateRef": {
+                                  "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                  "items": {
+                                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "maxItems": 1,
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "sni": {
+                                  "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                  "maxLength": 253,
+                                  "minLength": 1,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                  "type": "string"
+                                },
+                                "verifySubjectAltNames": {
+                                  "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                  "items": {
+                                    "maxLength": 256,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "maxItems": 16,
+                                  "minItems": 1,
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                  "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                },
+                                {
+                                  "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                  "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                },
+                                {
+                                  "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                  "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                }
+                              ]
+                            },
+                            "transformation": {
+                              "description": "transformation is used to mutate and transform requests and responses sent to and from the backend.",
+                              "properties": {
+                                "request": {
+                                  "description": "`request` is used to modify the request path.",
+                                  "properties": {
+                                    "add": {
+                                      "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "The name of the header to add.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                              }
+                                            ]
+                                          },
+                                          "value": {
+                                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "name"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    },
+                                    "body": {
+                                      "description": "`body` controls manipulation of the HTTP body.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "metadata": {
+                                      "additionalProperties": {
+                                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                                        "maxLength": 16384,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                                      "maxProperties": 16,
+                                      "minProperties": 1,
+                                      "type": "object"
+                                    },
+                                    "remove": {
+                                      "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                                      "items": {
+                                        "description": "An HTTP Header Name.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                          }
+                                        ]
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "set": {
+                                      "description": "`set` is a list of headers and the value they should be set to.",
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "The name of the header to add.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                              }
+                                            ]
+                                          },
+                                          "value": {
+                                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "name"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                                    }
+                                  ]
+                                },
+                                "response": {
+                                  "description": "`response` is used to modify the response path.",
+                                  "properties": {
+                                    "add": {
+                                      "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "The name of the header to add.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                              }
+                                            ]
+                                          },
+                                          "value": {
+                                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "name"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    },
+                                    "body": {
+                                      "description": "`body` controls manipulation of the HTTP body.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "metadata": {
+                                      "additionalProperties": {
+                                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                                        "maxLength": 16384,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      },
+                                      "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                                      "maxProperties": 16,
+                                      "minProperties": 1,
+                                      "type": "object"
+                                    },
+                                    "remove": {
+                                      "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                                      "items": {
+                                        "description": "An HTTP Header Name.",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                          }
+                                        ]
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-type": "set"
+                                    },
+                                    "set": {
+                                      "description": "`set` is a list of headers and the value they should be set to.",
+                                      "items": {
+                                        "properties": {
+                                          "name": {
+                                            "description": "The name of the header to add.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                              }
+                                            ]
+                                          },
+                                          "value": {
+                                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "name",
+                                          "value"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array",
+                                      "x-kubernetes-list-map-keys": [
+                                        "name"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                                    }
+                                  ]
+                                }
+                              },
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "at least one of the fields in [request response] must be set",
+                                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                                }
+                              ]
+                            },
+                            "tunnel": {
+                              "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                              "properties": {
+                                "backendRef": {
+                                  "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                  "properties": {
+                                    "group": {
+                                      "default": "",
+                                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                      "maxLength": 253,
+                                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                      "type": "string"
+                                    },
+                                    "kind": {
+                                      "default": "Service",
+                                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                      "maxLength": 63,
+                                      "minLength": 1,
+                                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name is the name of the referent.",
+                                      "maxLength": 253,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                      "maxLength": 63,
+                                      "minLength": 1,
+                                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                      "format": "int32",
+                                      "maximum": 65535,
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "type": "object",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "Must have port for Service reference",
+                                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "backendRef"
+                              ],
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "at least one of the fields in [ai auth health http tcp tls transformation tunnel] must be set",
+                              "rule": "[has(self.ai),has(self.auth),has(self.health),has(self.http),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
+                            }
+                          ]
+                        },
+                        "port": {
+                          "description": "Port specifies the port to send the requests to.",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "vertexai": {
+                          "description": "Vertex AI provider",
+                          "properties": {
+                            "model": {
+                              "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                              "maxLength": 256,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "projectId": {
+                              "description": "The ID of the Google Cloud Project that you use for the Vertex AI.",
+                              "maxLength": 64,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "region": {
+                              "default": "global",
+                              "description": "The location of the Google Cloud Project that you use for the Vertex AI.\nDefaults to `global` if not specified.",
+                              "maxLength": 64,
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "projectId"
+                          ],
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "both host and port must be set together",
+                          "rule": "has(self.host) || has(self.port) ? has(self.host) && has(self.port) : true"
+                        },
+                        {
+                          "message": "path and pathPrefix are mutually exclusive",
+                          "rule": "!(has(self.path) && has(self.pathPrefix))"
+                        },
+                        {
+                          "message": "pathPrefix requires host to be set",
+                          "rule": "has(self.pathPrefix) ? has(self.host) : true"
+                        },
+                        {
+                          "message": "exactly one of the fields in [openai azureopenai azure anthropic gemini vertexai bedrock] must be set",
+                          "rule": "[has(self.openai),has(self.azureopenai),has(self.azure),has(self.anthropic),has(self.gemini),has(self.vertexai),has(self.bedrock)].filter(x,x==true).size() == 1"
+                        }
+                      ]
+                    },
+                    "maxItems": 16,
+                    "minItems": 1,
+                    "type": "array",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "provider names must be unique within a group",
+                        "rule": "self.all(p1, self.exists_one(p2, p1.name == p2.name))"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "providers"
+                ],
+                "type": "object"
+              },
+              "maxItems": 8,
+              "minItems": 1,
+              "type": "array"
+            },
+            "provider": {
+              "description": "`provider` specifies configuration for how to reach the configured LLM\nprovider.",
+              "properties": {
+                "anthropic": {
+                  "description": "Anthropic provider",
+                  "properties": {
+                    "model": {
+                      "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "azure": {
+                  "description": "Azure provider with resource-based configuration.\nSupports both Azure OpenAI and Azure AI Foundry resource types.",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "The version of the Azure OpenAI API to use.\nIf unset, defaults to `v1`.",
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "model": {
+                      "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "projectName": {
+                      "description": "The Foundry project name, required when `resourceType` is `Foundry`.\nUsed to construct paths: /api/projects/{projectName}/openai/v1/...",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "resourceName": {
+                      "description": "The Azure resource name used to construct the endpoint host.\nFor OpenAI: {resourceName}.openai.azure.com\nFor Foundry: {resourceName}-resource.services.ai.azure.com",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "resourceType": {
+                      "description": "The type of Azure endpoint. Determines the host suffix.",
+                      "enum": [
+                        "OpenAI",
+                        "Foundry"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "resourceName",
+                    "resourceType"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "projectName is required when resourceType is Foundry",
+                      "rule": "self.resourceType != 'Foundry' || has(self.projectName)"
+                    }
+                  ]
+                },
+                "azureopenai": {
+                  "description": "Azure OpenAI provider",
+                  "properties": {
+                    "apiVersion": {
+                      "description": "The version of the Azure OpenAI API to use.\nFor more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/foundry/openai/reference).\nIf unset, defaults to `v1`.",
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "deploymentName": {
+                      "description": "The name of the Azure OpenAI model deployment to use.\nFor more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure?view=foundry-classic).\nThis is required if `apiVersion` is not `v1`. For `v1`, the model can be\nset in the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "description": "The endpoint for the Azure OpenAI API to use, such as `my-endpoint.openai.azure.com`.\nIf the scheme is included, it is stripped.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "endpoint"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "deploymentName is required for this apiVersion",
+                      "rule": "!has(self.apiVersion) || self.apiVersion == 'v1' ? true : has(self.deploymentName)"
+                    }
+                  ]
+                },
+                "bedrock": {
+                  "description": "Bedrock provider",
+                  "properties": {
+                    "guardrail": {
+                      "description": "`guardrail` configures the Guardrail policy to use for the backend. See\n<https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html>.\nIf not specified, the AWS Guardrail policy will not be used.",
+                      "properties": {
+                        "identifier": {
+                          "description": "GuardrailIdentifier is the identifier of the Guardrail policy to use for the backend.",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "version": {
+                          "description": "GuardrailVersion is the version of the Guardrail policy to use for the backend.",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "identifier",
+                        "version"
+                      ],
+                      "type": "object"
+                    },
+                    "model": {
+                      "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "region": {
+                      "default": "us-east-1",
+                      "description": "Region is the AWS region to use for the backend.\nDefaults to `us-east-1` if not specified.",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9-]+$",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "gemini": {
+                  "description": "Gemini provider",
+                  "properties": {
+                    "model": {
+                      "description": "Optional: Override the model name, such as `gemini-2.5-pro`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "host": {
+                  "description": "Host specifies the hostname to send the requests to.\nIf not specified, the default hostname for the provider is used.",
+                  "maxLength": 256,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "openai": {
+                  "description": "OpenAI provider",
+                  "properties": {
+                    "model": {
+                      "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "path": {
+                  "description": "Path specifies the URL path to use for the LLM provider API requests.\nThis is useful when you need to route requests to a different API endpoint while maintaining\ncompatibility with the original provider's API structure.\nIf not specified, the default path for the provider is used.",
+                  "maxLength": 1024,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "pathPrefix": {
+                  "description": "PathPrefix overrides the default base path prefix (e.g. \"/v1\") for upstream requests.\nPath translation for cross-format requests still applies using this prefix.\nOnly supported for OpenAI and Anthropic providers.",
+                  "maxLength": 1024,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "port": {
+                  "description": "Port specifies the port to send the requests to.",
+                  "format": "int32",
+                  "maximum": 65535,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "vertexai": {
+                  "description": "Vertex AI provider",
+                  "properties": {
+                    "model": {
+                      "description": "Optional: Override the model name, such as `gpt-4o-mini`.\nIf unset, the model name is taken from the request.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "The ID of the Google Cloud Project that you use for the Vertex AI.",
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "region": {
+                      "default": "global",
+                      "description": "The location of the Google Cloud Project that you use for the Vertex AI.\nDefaults to `global` if not specified.",
+                      "maxLength": 64,
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "projectId"
+                  ],
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "both host and port must be set together",
+                  "rule": "has(self.host) || has(self.port) ? has(self.host) && has(self.port) : true"
+                },
+                {
+                  "message": "path and pathPrefix are mutually exclusive",
+                  "rule": "!(has(self.path) && has(self.pathPrefix))"
+                },
+                {
+                  "message": "pathPrefix requires host to be set",
+                  "rule": "has(self.pathPrefix) ? has(self.host) : true"
+                },
+                {
+                  "message": "exactly one of the fields in [openai azureopenai azure anthropic gemini vertexai bedrock] must be set",
+                  "rule": "[has(self.openai),has(self.azureopenai),has(self.azure),has(self.anthropic),has(self.gemini),has(self.vertexai),has(self.bedrock)].filter(x,x==true).size() == 1"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "exactly one of the fields in [provider groups] must be set",
+              "rule": "[has(self.provider),has(self.groups)].filter(x,x==true).size() == 1"
+            }
+          ]
+        },
+        "aws": {
+          "description": "aws represents an AWS service backend (AgentCore, etc.).",
+          "properties": {
+            "agentCore": {
+              "description": "agentCore configures Amazon Bedrock AgentCore as a backend.",
+              "properties": {
+                "agentRuntimeArn": {
+                  "description": "agentRuntimeArn is the ARN of the AgentCore runtime.",
+                  "type": "string"
+                },
+                "qualifier": {
+                  "description": "qualifier optionally specifies the alias or version qualifier.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "agentRuntimeArn"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "exactly one of the fields in [agentCore] must be set",
+              "rule": "[has(self.agentCore)].filter(x,x==true).size() == 1"
+            }
+          ]
+        },
+        "dynamicForwardProxy": {
+          "description": "dynamicForwardProxy configures the proxy to dynamically send requests to the destination based on the incoming\nrequest HTTP host header, or TLS SNI for TLS traffic.\n\nNote: this Backend type enables users to send trigger the proxy to send requests to arbitrary destinations. Proper\naccess controls must be put in place when using this backend type.",
+          "type": "object"
+        },
+        "mcp": {
+          "description": "mcp represents an MCP backend",
+          "properties": {
+            "failureMode": {
+              "description": "`failureMode` controls behavior when MCP targets fail to initialize or\nbecome unavailable at runtime. `FailOpen` skips failed targets and\ncontinues serving from healthy ones. `FailClosed` (default) fails the\nentire session if any target fails.",
+              "enum": [
+                "FailOpen",
+                "FailClosed"
+              ],
+              "type": "string"
+            },
+            "sessionRouting": {
+              "description": "`sessionRouting` configures MCP session behavior for requests.\nDefaults to `Stateful` if not set.",
+              "enum": [
+                "Stateful",
+                "Stateless"
+              ],
+              "type": "string"
+            },
+            "targets": {
+              "description": "`targets` is a list of MCP targets to use for this backend. Policies\ntargeting MCP targets must use `targetRefs[].sectionName` to select\nthe target by name.",
+              "items": {
+                "description": "McpTargetSelector defines the MCPBackend target to use for this backend.",
+                "properties": {
+                  "name": {
+                    "description": "Name of the MCP target.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "selector": {
+                    "description": "`selector` is the label selector used to select `Service` resources.\nIf policies are needed on a per-service basis, `AgentgatewayPolicy` can\ntarget the desired `Service`.",
+                    "properties": {
+                      "namespaces": {
+                        "description": "`namespace` is the label selector for namespaces that `Service`\nresources should be selected from. If unset, only the namespace of the\n`AgentgatewayBackend` is searched.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "services": {
+                        "description": "`services` is the label selector for which `Service` resources should be\nselected.",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array",
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "at least one of the fields in [namespaces services] must be set",
+                        "rule": "[has(self.namespaces),has(self.services)].filter(x,x==true).size() >= 1"
+                      }
+                    ]
+                  },
+                  "static": {
+                    "description": "`static` configures a static MCP destination. When connecting to\nin-cluster `Service` resources, it is recommended to use `selector`\ninstead.",
+                    "properties": {
+                      "backendRef": {
+                        "description": "`backendRef` references a namespace-local `Service` resource by name.\nWhen set, this replaces `host` only; `port`, `path`, and `protocol`\nremain configured on this target.",
+                        "properties": {
+                          "name": {
+                            "default": "",
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "host": {
+                        "description": "Host is the hostname or IP address of the MCP target.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "Path is the URL path of the MCP target endpoint.\nDefaults to `\"/sse\"` for the `SSE` protocol or `\"/mcp\"` for the\n`StreamableHTTP` protocol if not specified.",
+                        "maxLength": 1024,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policies": {
+                        "description": "`policies` controls policies for communicating with this backend.\nPolicies may also be set in `AgentgatewayPolicy`, or in the top-level\n`AgentgatewayBackend`. Policies are merged on a field-level basis, with\norder: `AgentgatewayPolicy` < `AgentgatewayBackend` < `AgentgatewayBackend` MCP (this field).\nThis field may only be used with host-based static targets, not\n`backendRef`.",
+                        "properties": {
+                          "auth": {
+                            "description": "`auth` defines settings for managing authentication to the backend.",
+                            "properties": {
+                              "aws": {
+                                "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                "properties": {
+                                  "secretRef": {
+                                    "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                },
+                                "required": [
+                                  "secretRef"
+                                ],
+                                "type": "object"
+                              },
+                              "azure": {
+                                "description": "Azure specifies an Azure authentication method for the backend.",
+                                "properties": {
+                                  "managedIdentity": {
+                                    "description": "Details for managed identity authentication",
+                                    "properties": {
+                                      "clientId": {
+                                        "type": "string"
+                                      },
+                                      "objectId": {
+                                        "type": "string"
+                                      },
+                                      "resourceId": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "clientId",
+                                      "objectId",
+                                      "resourceId"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "secretRef": {
+                                    "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "gcp": {
+                                "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                "properties": {
+                                  "audience": {
+                                    "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                    "maxLength": 256,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                    "properties": {
+                                      "name": {
+                                        "default": "",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "type": {
+                                    "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                    "enum": [
+                                      "AccessToken",
+                                      "IdToken"
+                                    ],
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "audience is only valid with IdToken",
+                                    "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                  }
+                                ]
+                              },
+                              "key": {
+                                "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                "maxLength": 2048,
+                                "type": "string"
+                              },
+                              "location": {
+                                "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                "properties": {
+                                  "cookie": {
+                                    "properties": {
+                                      "name": {
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "header": {
+                                    "properties": {
+                                      "name": {
+                                        "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                        "type": "string"
+                                      },
+                                      "prefix": {
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "queryParameter": {
+                                    "properties": {
+                                      "name": {
+                                        "maxLength": 256,
+                                        "minLength": 1,
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                    "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                  }
+                                ]
+                              },
+                              "passthrough": {
+                                "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                "type": "object"
+                              },
+                              "secretRef": {
+                                "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                "properties": {
+                                  "name": {
+                                    "default": "",
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "location may only be set for key or passthrough auth",
+                                "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                              },
+                              {
+                                "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                              }
+                            ]
+                          },
+                          "http": {
+                            "description": "http defines settings for managing HTTP requests to the backend.",
+                            "properties": {
+                              "requestTimeout": {
+                                "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "invalid duration value",
+                                    "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                  },
+                                  {
+                                    "message": "requestTimeout must be at least 1ms",
+                                    "rule": "duration(self) >= duration('1ms')"
+                                  }
+                                ]
+                              },
+                              "version": {
+                                "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                "enum": [
+                                  "HTTP1",
+                                  "HTTP2"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "tcp": {
+                            "description": "tcp defines settings for managing TCP connections to the backend.",
+                            "properties": {
+                              "connectTimeout": {
+                                "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "invalid duration value",
+                                    "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                  },
+                                  {
+                                    "message": "connectTimeout must be at least 100ms",
+                                    "rule": "duration(self) >= duration('100ms')"
+                                  }
+                                ]
+                              },
+                              "keepalive": {
+                                "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                "properties": {
+                                  "interval": {
+                                    "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "interval must be at least 1 second",
+                                        "rule": "duration(self) >= duration('1s')"
+                                      }
+                                    ]
+                                  },
+                                  "retries": {
+                                    "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                    "format": "int32",
+                                    "maximum": 64,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  },
+                                  "time": {
+                                    "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                    "type": "string",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "invalid duration value",
+                                        "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                      },
+                                      {
+                                        "message": "time must be at least 1 second",
+                                        "rule": "duration(self) >= duration('1s')"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "tls": {
+                            "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                            "properties": {
+                              "alpnProtocols": {
+                                "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                "items": {
+                                  "maxLength": 64,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array"
+                              },
+                              "caCertificateRefs": {
+                                "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                "items": {
+                                  "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                  "properties": {
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "maxItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "insecureSkipVerify": {
+                                "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                "enum": [
+                                  "All",
+                                  "Hostname"
+                                ],
+                                "type": "string"
+                              },
+                              "keyExchangeGroups": {
+                                "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                "items": {
+                                  "enum": [
+                                    "X25519",
+                                    "P-256",
+                                    "P-384",
+                                    "X25519_MLKEM768"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mtlsCertificateRef": {
+                                "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                "items": {
+                                  "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                  "properties": {
+                                    "name": {
+                                      "default": "",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "maxItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "sni": {
+                                "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                "type": "string"
+                              },
+                              "verifySubjectAltNames": {
+                                "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                "items": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                              },
+                              {
+                                "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                              },
+                              {
+                                "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                              }
+                            ]
+                          },
+                          "tunnel": {
+                            "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "port": {
+                        "description": "Port is the port number of the MCP target.",
+                        "format": "int32",
+                        "maximum": 65535,
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "protocol": {
+                        "description": "Protocol is the protocol to use for the connection to the MCP\ntarget.",
+                        "enum": [
+                          "StreamableHTTP",
+                          "SSE"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "port"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "mcp target policies may not be used with backendRef",
+                        "rule": "!has(self.backendRef) || !has(self.policies)"
+                      },
+                      {
+                        "message": "exactly one of the fields in [host backendRef] must be set",
+                        "rule": "[has(self.host),has(self.backendRef)].filter(x,x==true).size() == 1"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "exactly one of the fields in [selector static] must be set",
+                    "rule": "[has(self.selector),has(self.static)].filter(x,x==true).size() == 1"
+                  }
+                ]
+              },
+              "maxItems": 32,
+              "minItems": 1,
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map",
+              "x-kubernetes-validations": [
+                {
+                  "message": "target names must be unique",
+                  "rule": "self.all(t1, self.exists_one(t2, t1.name == t2.name))"
+                }
+              ]
+            }
+          },
+          "required": [
+            "targets"
+          ],
+          "type": "object"
+        },
+        "policies": {
+          "description": "policies controls policies for communicating with this backend. Policies may also be set in AgentgatewayPolicy;\npolicies are merged on a field-level basis, with policies on the Backend (this field) taking precedence.",
+          "properties": {
+            "ai": {
+              "description": "`ai` specifies settings for AI workloads. This is only applicable when\nconnecting to a `Backend` of type `ai`.",
+              "properties": {
+                "defaults": {
+                  "description": "Provide defaults to merge with user input fields. If the field is already set, the field in the request is used.",
+                  "items": {
+                    "description": "FieldDefault provides default values for specific fields in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                    "properties": {
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "The name of the field.",
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The field default value, which can be any JSON Data Type.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "required": [
+                      "field",
+                      "value"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "modelAliases": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ModelAliases maps friendly model names to actual provider model names.\nExample: `{\"fast\": \"gpt-3.5-turbo\", \"smart\": \"gpt-4-turbo\"}`.\nNote: This field is only applicable when using the agentgateway data plane.",
+                  "maxProperties": 64,
+                  "type": "object"
+                },
+                "overrides": {
+                  "description": "Provide overrides to merge with user input fields. If the field is already set, the field will be overwritten.",
+                  "items": {
+                    "description": "FieldDefault provides default values for specific fields in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                    "properties": {
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "The name of the field.",
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The field default value, which can be any JSON Data Type.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "required": [
+                      "field",
+                      "value"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "prompt": {
+                  "description": "Enrich requests sent to the LLM provider by appending and prepending system prompts. This can be configured only for\nLLM providers that use the `CHAT` or `CHAT_STREAMING` API route type.",
+                  "properties": {
+                    "append": {
+                      "description": "A list of messages to be appended to the prompt sent by the client.",
+                      "items": {
+                        "description": "An entry for a message to prepend or append to each prompt.",
+                        "properties": {
+                          "content": {
+                            "description": "String content of the message.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "role"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "prepend": {
+                      "description": "A list of messages to be prepended to the prompt sent by the client.",
+                      "items": {
+                        "description": "An entry for a message to prepend or append to each prompt.",
+                        "properties": {
+                          "content": {
+                            "description": "String content of the message.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "role"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "promptCaching": {
+                  "description": "`promptCaching` enables automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
+                  "properties": {
+                    "cacheMessageOffset": {
+                      "default": 0,
+                      "description": "CacheMessageOffset shifts the message cache point further back in the\nconversation. 0 (default) places it at the second-to-last message.\nHigher values move it N additional messages towards the start, clamped\nto bounds.",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "cacheMessages": {
+                      "default": true,
+                      "description": "CacheMessages enables caching for conversation messages.\nCaches all messages in the conversation for cost savings.",
+                      "type": "boolean"
+                    },
+                    "cacheSystem": {
+                      "default": true,
+                      "description": "CacheSystem enables caching for system prompts.\nInserts a cache point after all system messages.",
+                      "type": "boolean"
+                    },
+                    "cacheTools": {
+                      "default": false,
+                      "description": "CacheTools enables caching for tool definitions.\nInserts a cache point after all tool specifications.",
+                      "type": "boolean"
+                    },
+                    "minTokens": {
+                      "default": 1024,
+                      "description": "MinTokens specifies the minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count × 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "promptGuard": {
+                  "description": "`promptGuard` enables adding guardrails to LLM requests and responses.",
+                  "properties": {
+                    "request": {
+                      "description": "Prompt guards to apply to requests sent by the client.",
+                      "items": {
+                        "description": "PromptguardRequest defines the prompt guards to apply to requests sent by the client.",
+                        "properties": {
+                          "bedrockGuardrails": {
+                            "description": "`bedrockGuardrails` configures AWS Bedrock Guardrails for prompt\nguarding.",
+                            "properties": {
+                              "identifier": {
+                                "description": "GuardrailIdentifier is the identifier of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "region": {
+                                "description": "Region is the AWS region where the guardrail is deployed (for example,\n`us-west-2`).",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "version": {
+                                "description": "GuardrailVersion is the version of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "identifier",
+                              "region",
+                              "version"
+                            ],
+                            "type": "object"
+                          },
+                          "googleModelArmor": {
+                            "description": "`googleModelArmor` configures Google Model Armor for prompt guarding.",
+                            "properties": {
+                              "location": {
+                                "default": "us-central1",
+                                "description": "Location is the Google Cloud location (for example, `us-central1`).\nDefaults to `us-central1` if not specified.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with Google Model Armor.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projectId": {
+                                "description": "ProjectID is the Google Cloud project ID.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "templateId": {
+                                "description": "TemplateID is the template ID for Google Model Armor.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "projectId",
+                              "templateId"
+                            ],
+                            "type": "object"
+                          },
+                          "openAIModeration": {
+                            "description": "`openAIModeration` passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
+                            "properties": {
+                              "model": {
+                                "description": "`model` specifies the moderation model to use. For example,\n`omni-moderation`.",
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with OpenAI.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "regex": {
+                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                            "properties": {
+                              "action": {
+                                "default": "Mask",
+                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                "enum": [
+                                  "Mask",
+                                  "Reject"
+                                ],
+                                "type": "string"
+                              },
+                              "builtins": {
+                                "description": "A list of built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                  "enum": [
+                                    "Ssn",
+                                    "CreditCard",
+                                    "PhoneNumber",
+                                    "Email",
+                                    "CaSin"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matches": {
+                                "description": "A list of regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "maxLength": 1024,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "response": {
+                            "description": "A custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                            "properties": {
+                              "message": {
+                                "default": "The request was rejected due to inappropriate content",
+                                "description": "A custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                "type": "string"
+                              },
+                              "statusCode": {
+                                "default": 403,
+                                "description": "The status code to return to the client. Defaults to 403.",
+                                "format": "int32",
+                                "maximum": 599,
+                                "minimum": 200,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [message statusCode] must be set",
+                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                              }
+                            ]
+                          },
+                          "webhook": {
+                            "description": "Configure a webhook to forward requests to for prompt guarding.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "backendRef references the webhook server to reach.\n\nSupported types: Service and Backend.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ]
+                              },
+                              "forwardHeaderMatches": {
+                                "description": "ForwardHeaderMatches defines a list of HTTP header matches that will be\nused to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                "items": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
+                            "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                          }
+                        ]
+                      },
+                      "maxItems": 8,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "response": {
+                      "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                      "items": {
+                        "description": "PromptguardResponse configures the response that the prompt guard applies to responses returned by the LLM provider.",
+                        "properties": {
+                          "bedrockGuardrails": {
+                            "description": "`bedrockGuardrails` configures AWS Bedrock Guardrails for prompt\nguarding.",
+                            "properties": {
+                              "identifier": {
+                                "description": "GuardrailIdentifier is the identifier of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "region": {
+                                "description": "Region is the AWS region where the guardrail is deployed (for example,\n`us-west-2`).",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "version": {
+                                "description": "GuardrailVersion is the version of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "identifier",
+                              "region",
+                              "version"
+                            ],
+                            "type": "object"
+                          },
+                          "googleModelArmor": {
+                            "description": "`googleModelArmor` configures Google Model Armor for prompt guarding.",
+                            "properties": {
+                              "location": {
+                                "default": "us-central1",
+                                "description": "Location is the Google Cloud location (for example, `us-central1`).\nDefaults to `us-central1` if not specified.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with Google Model Armor.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projectId": {
+                                "description": "ProjectID is the Google Cloud project ID.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "templateId": {
+                                "description": "TemplateID is the template ID for Google Model Armor.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "projectId",
+                              "templateId"
+                            ],
+                            "type": "object"
+                          },
+                          "regex": {
+                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                            "properties": {
+                              "action": {
+                                "default": "Mask",
+                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                "enum": [
+                                  "Mask",
+                                  "Reject"
+                                ],
+                                "type": "string"
+                              },
+                              "builtins": {
+                                "description": "A list of built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                  "enum": [
+                                    "Ssn",
+                                    "CreditCard",
+                                    "PhoneNumber",
+                                    "Email",
+                                    "CaSin"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matches": {
+                                "description": "A list of regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "maxLength": 1024,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "response": {
+                            "description": "A custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
+                            "properties": {
+                              "message": {
+                                "default": "The request was rejected due to inappropriate content",
+                                "description": "A custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                "type": "string"
+                              },
+                              "statusCode": {
+                                "default": 403,
+                                "description": "The status code to return to the client. Defaults to 403.",
+                                "format": "int32",
+                                "maximum": 599,
+                                "minimum": 200,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [message statusCode] must be set",
+                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                              }
+                            ]
+                          },
+                          "webhook": {
+                            "description": "Configure a webhook to forward responses to for prompt guarding.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "backendRef references the webhook server to reach.\n\nSupported types: Service and Backend.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ]
+                              },
+                              "forwardHeaderMatches": {
+                                "description": "ForwardHeaderMatches defines a list of HTTP header matches that will be\nused to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                "items": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
+                            "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                          }
+                        ]
+                      },
+                      "maxItems": 8,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [request response] must be set",
+                      "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                },
+                "routes": {
+                  "additionalProperties": {
+                    "description": "RouteType specifies how the AI gateway should process incoming requests\nbased on the URL path and the API format expected.",
+                    "enum": [
+                      "Completions",
+                      "Messages",
+                      "Models",
+                      "Passthrough",
+                      "Detect",
+                      "Responses",
+                      "AnthropicTokenCount",
+                      "Embeddings",
+                      "Realtime"
+                    ],
+                    "type": "string"
+                  },
+                  "description": "`routes` defines how to identify the type of traffic to handle.\nThe keys are URL path suffixes matched using ends-with comparison, for\nexample `\"/v1/chat/completions\"`.\nThe special `*` wildcard matches any path.\nIf not specified, all traffic defaults to `completions` type.",
+                  "type": "object"
+                },
+                "transformations": {
+                  "description": "Provide CEL transformations to compute and set fields in the request body.\nThe expression result overwrites any existing value for that field.\nThis has a higher priority than `overrides` if both are set for the same\nkey.",
+                  "items": {
+                    "description": "FieldTransformation maps a request JSON field to a CEL expression string.\nThe expression is evaluated against the current request body and its result\nis assigned to the configured field.",
+                    "properties": {
+                      "expression": {
+                        "description": "CEL expression used to compute the field value.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "The name of the field to set.",
+                        "maxLength": 256,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression",
+                      "field"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
+                  "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "auth": {
+              "description": "`auth` defines settings for managing authentication to the backend.",
+              "properties": {
+                "aws": {
+                  "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object"
+                },
+                "azure": {
+                  "description": "Azure specifies an Azure authentication method for the backend.",
+                  "properties": {
+                    "managedIdentity": {
+                      "description": "Details for managed identity authentication",
+                      "properties": {
+                        "clientId": {
+                          "type": "string"
+                        },
+                        "objectId": {
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "clientId",
+                        "objectId",
+                        "resourceId"
+                      ],
+                      "type": "object"
+                    },
+                    "secretRef": {
+                      "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    }
+                  },
+                  "type": "object"
+                },
+                "gcp": {
+                  "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                  "properties": {
+                    "audience": {
+                      "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "type": {
+                      "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                      "enum": [
+                        "AccessToken",
+                        "IdToken"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "audience is only valid with IdToken",
+                      "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                    }
+                  ]
+                },
+                "key": {
+                  "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                  "maxLength": 2048,
+                  "type": "string"
+                },
+                "location": {
+                  "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                    }
+                  ]
+                },
+                "passthrough": {
+                  "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                  "type": "object"
+                },
+                "secretRef": {
+                  "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "location may only be set for key or passthrough auth",
+                  "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                },
+                {
+                  "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                }
+              ]
+            },
+            "extAuth": {
+              "description": "extAuth specifies the external authentication configuration for requests\nsent to this backend.",
+              "properties": {
+                "backendRef": {
+                  "description": "`backendRef` references the External Authorization server to reach.\n\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ]
+                },
+                "failureMode": {
+                  "description": "FailureMode controls behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
+                  "enum": [
+                    "FailOpen",
+                    "FailClosed"
+                  ],
+                  "type": "string"
+                },
+                "forwardBody": {
+                  "description": "`forwardBody` configures whether to include the HTTP body in the request.\nIf enabled, the request body will be buffered.",
+                  "properties": {
+                    "maxSize": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "`maxSize` specifies, in bytes, the largest body that will be buffered\nand sent to the authorization server. If the body size is larger than\n`maxSize`, then the request will be rejected with a response.",
+                      "maxLength": 32,
+                      "minLength": 1,
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true,
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "value must be at least 1 byte and fit within uint32",
+                          "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "maxSize"
+                  ],
+                  "type": "object"
+                },
+                "grpc": {
+                  "description": "grpc specifies that the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
+                  "properties": {
+                    "contextExtensions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "`contextExtensions` specifies additional arbitrary key-value pairs to\nsend to the authorization server in the `context_extensions` field.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "requestMetadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`requestMetadata` specifies metadata to be sent to the authorization\nserver. This maps to the `metadata_context.filter_metadata` field of the\nrequest, and allows dynamic CEL expressions. If unset, by default the\n`envoy.filters.http.jwt_authn` key is set if the JWT policy is used as\nwell, for compatibility.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "http": {
+                  "description": "`http` specifies that the HTTP protocol should be used for connecting to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
+                  "properties": {
+                    "addRequestHeaders": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`addRequestHeaders` specifies what additional headers to add to the\nrequest to the authorization server. While `allowedRequestHeaders` just\npasses the original headers through, `addRequestHeaders` allows defining\ncustom headers based on CEL expressions.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "allowedRequestHeaders": {
+                      "description": "`allowedRequestHeaders` specifies what additional headers from the client request\nwill be sent to the authorization server.\n\nIf unset, the following headers are sent by default: `Authorization`.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "allowedResponseHeaders": {
+                      "description": "`allowedResponseHeaders` specifies what headers from the authorization response\nwill be copied into the request to the backend.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "path": {
+                      "description": "`path` specifies the path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "redirect": {
+                      "description": "`redirect` defines an optional expression to determine a path to\nredirect to on authorization failure. This is useful to redirect to a\nsign-in page.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "responseMetadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`responseMetadata` specifies what metadata fields should be constructed\nfrom the authorization response. These will be included under the\n`extauthz` variable in future CEL expressions. Setting this is useful\nfor things like logging usernames, without needing to include them as\nheaders to the backend, as `allowedResponseHeaders` would.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "health": {
+              "description": "health defines settings for passive and active health checking.",
+              "properties": {
+                "eviction": {
+                  "description": "Eviction defines settings for evicting unhealthy backends.",
+                  "properties": {
+                    "consecutiveFailures": {
+                      "description": "ConsecutiveFailures is the number of consecutive unhealthy responses required before the backend is evicted.\nFor example, a value of 5 means the backend must receive 5 unhealthy responses in a row before being evicted.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response can trigger eviction.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "duration": {
+                      "default": "3s",
+                      "description": "Duration specifies the base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "evictionDuration must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "healthThreshold": {
+                      "description": "HealthThreshold is the EWMA (exponentially-weighted moving average) health score threshold, expressed as 0–100.\nWhen set, a backend is only evicted if its computed health drops below this value after an unhealthy response.\nFor example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.\nUnlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average\nso a single success in a stream of failures can delay eviction.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response triggers eviction.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "restoreHealth": {
+                      "description": "RestoreHealth is the health score (0–100) assigned to a backend when it returns from eviction.\nFor gradual recovery, set below 100; for full recovery immediately, set 100.\nIf unset, the backend resumes with the health it had when evicted.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "unhealthyCondition": {
+                  "description": "UnhealthyCondition is a CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "http": {
+              "description": "http defines settings for managing HTTP requests to the backend.",
+              "properties": {
+                "requestTimeout": {
+                  "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "requestTimeout must be at least 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
+                },
+                "version": {
+                  "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                  "enum": [
+                    "HTTP1",
+                    "HTTP2"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "mcp": {
+              "description": "`mcp` specifies settings for MCP workloads. This is only applicable when\nconnecting to a `Backend` of type `mcp`.",
+              "properties": {
+                "authentication": {
+                  "description": "`authentication` defines `MCPBackend`-specific authentication rules.\n\nThis field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before\nother policies such as transformation and rate limiting.",
+                  "properties": {
+                    "audiences": {
+                      "description": "`audiences` specifies the list of allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "issuer": {
+                      "description": "`issuer` identifies the IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "jwks": {
+                      "description": "`jwks` defines the remote JSON Web Key used to validate the signature of\nthe JWT.",
+                      "properties": {
+                        "backendRef": {
+                          "description": "`backendRef` references the remote JWKS server to reach.\nSupported types are `Service` and static `Backend`. An\n`AgentgatewayPolicy` containing backend TLS config can then be attached\nto the `Service` or `Backend` in order to set TLS options for a\nconnection to the remote `jwks` source.",
+                          "properties": {
+                            "group": {
+                              "default": "",
+                              "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                              "maxLength": 253,
+                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "default": "Service",
+                              "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the referent.",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                              "format": "int32",
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Must have port for Service reference",
+                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                            }
+                          ]
+                        },
+                        "cacheDuration": {
+                          "default": "5m",
+                          "type": "string",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "invalid duration value",
+                              "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                            },
+                            {
+                              "message": "cacheDuration must be at least 5m.",
+                              "rule": "duration(self) >= duration('5m')"
+                            }
+                          ]
+                        },
+                        "jwksPath": {
+                          "description": "Path to the IdP `jwks` endpoint, relative to the root, commonly\n`\".well-known/jwks.json\"`.",
+                          "maxLength": 2000,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backendRef",
+                        "jwksPath"
+                      ],
+                      "type": "object"
+                    },
+                    "mode": {
+                      "default": "Strict",
+                      "description": "`mode` is the validation mode for JWT authentication.",
+                      "enum": [
+                        "Strict",
+                        "Optional",
+                        "Permissive"
+                      ],
+                      "type": "string"
+                    },
+                    "provider": {
+                      "description": "`provider` specifies the identity provider to use for authentication.",
+                      "enum": [
+                        "Auth0",
+                        "Keycloak"
+                      ],
+                      "type": "string"
+                    },
+                    "resourceMetadata": {
+                      "additionalProperties": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "description": "ResourceMetadata defines the metadata to use for MCP resources.",
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "jwks"
+                  ],
+                  "type": "object"
+                },
+                "authorization": {
+                  "description": "authorization defines MCPBackend level authorization. Unlike authorization at the HTTP level, which will reject\nunauthorized requests with a `403` error, this policy works at the\n`MCPBackend` level.\n\nList operations, such as `list_tools`, will have each item evaluated.\nItems that do not meet the rule will be filtered.\n\nGet or call operations, such as `call_tool`, will evaluate the specific\nitem and reject requests that do not meet the rule.",
+                  "properties": {
+                    "action": {
+                      "default": "Allow",
+                      "description": "`action` defines whether the rule allows, denies, or requires the request if\nmatched. If unspecified, the default is `Allow`.\nRequire policies are conjunctive across merged policies: all require policies must match.",
+                      "enum": [
+                        "Allow",
+                        "Deny",
+                        "Require"
+                      ],
+                      "type": "string"
+                    },
+                    "policy": {
+                      "description": "`policy` specifies the authorization rule to evaluate.\n\n* For `Allow` rules: any policy allows the request.\n* For `Require` rules: all policies must match for the request to be allowed.\n* For `Deny` rules: any matching policy denies the request. Note: a CEL expression that fails to evaluate is not\nconsidered to match, making this a risky policy; prefer to use `Require`.\n\nThe presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.\nWith no rules, all requires are allowed.",
+                      "properties": {
+                        "matchExpressions": {
+                          "description": "MatchExpressions defines a set of conditions that must be satisfied for the rule to match.\nThese expressions should be in the form of a Common Expression Language\n(`CEL`) expression.",
+                          "items": {
+                            "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "maxItems": 256,
+                          "minItems": 1,
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "matchExpressions"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "policy"
+                  ],
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [authentication authorization] must be set",
+                  "rule": "[has(self.authentication),has(self.authorization)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "tcp": {
+              "description": "tcp defines settings for managing TCP connections to the backend.",
+              "properties": {
+                "connectTimeout": {
+                  "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "connectTimeout must be at least 100ms",
+                      "rule": "duration(self) >= duration('100ms')"
+                    }
+                  ]
+                },
+                "keepalive": {
+                  "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                  "properties": {
+                    "interval": {
+                      "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "interval must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "retries": {
+                      "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                      "format": "int32",
+                      "maximum": 64,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "time": {
+                      "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "time must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "tls": {
+              "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+              "properties": {
+                "alpnProtocols": {
+                  "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                  "items": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "caCertificateRefs": {
+                  "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "insecureSkipVerify": {
+                  "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                  "enum": [
+                    "All",
+                    "Hostname"
+                  ],
+                  "type": "string"
+                },
+                "keyExchangeGroups": {
+                  "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                  "items": {
+                    "enum": [
+                      "X25519",
+                      "P-256",
+                      "P-384",
+                      "X25519_MLKEM768"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "mtlsCertificateRef": {
+                  "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "sni": {
+                  "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "type": "string"
+                },
+                "verifySubjectAltNames": {
+                  "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                  "items": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                  "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                },
+                {
+                  "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                  "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                },
+                {
+                  "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                  "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                }
+              ]
+            },
+            "transformation": {
+              "description": "transformation is used to mutate and transform requests and responses sent to and from the backend.",
+              "properties": {
+                "request": {
+                  "description": "`request` is used to modify the request path.",
+                  "properties": {
+                    "add": {
+                      "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "`body` controls manipulation of the HTTP body.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "An HTTP Header Name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "`set` is a list of headers and the value they should be set to.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                },
+                "response": {
+                  "description": "`response` is used to modify the response path.",
+                  "properties": {
+                    "add": {
+                      "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "`body` controls manipulation of the HTTP body.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "An HTTP Header Name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "`set` is a list of headers and the value they should be set to.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [request response] must be set",
+                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "tunnel": {
+              "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+              "properties": {
+                "backendRef": {
+                  "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "backendRef"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of the fields in [ai auth extAuth health http mcp tcp tls transformation tunnel] must be set",
+              "rule": "[has(self.ai),has(self.auth),has(self.extAuth),has(self.health),has(self.http),has(self.mcp),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
+            }
+          ]
+        },
+        "static": {
+          "description": "static represents a static hostname.",
+          "properties": {
+            "host": {
+              "description": "host to connect to (for TCP backends).",
+              "maxLength": 256,
+              "minLength": 1,
+              "type": "string"
+            },
+            "port": {
+              "description": "port to connect to (for TCP backends).",
+              "format": "int32",
+              "maximum": 65535,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "unixPath": {
+              "description": "unixPath is the filesystem path to a Unix Domain Socket. The gateway pod\nmust share a volume with the target (e.g., via emptyDir sidecar pattern).\nMutually exclusive with host/port.",
+              "minLength": 1,
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "must specify either unixPath or both host and port",
+              "rule": "has(self.unixPath) || (has(self.host) && has(self.port))"
+            },
+            {
+              "message": "unixPath and host/port are mutually exclusive",
+              "rule": "!has(self.unixPath) || (!has(self.host) && !has(self.port))"
+            }
+          ]
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "AI policies require AI backend",
+          "rule": "has(self.policies) && has(self.policies.ai) ? has(self.ai) : true"
+        },
+        {
+          "message": "MCP policies require MCP backend",
+          "rule": "has(self.policies) && has(self.policies.mcp) ? has(self.mcp) : true"
+        },
+        {
+          "message": "exactly one of the fields in [ai static dynamicForwardProxy mcp aws] must be set",
+          "rule": "[has(self.ai),has(self.static),has(self.dynamicForwardProxy),has(self.mcp),has(self.aws)].filter(x,x==true).size() == 1"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the current state of AgentgatewayBackend.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the list of conditions for the backend.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object"
+          },
+          "maxItems": 8,
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/agentgateway.dev/agentgatewayparameters_v1alpha1.json
+++ b/schemas/agentgateway.dev/agentgatewayparameters_v1alpha1.json
@@ -1,0 +1,499 @@
+{
+  "description": "AgentgatewayParameters are configuration that is used to dynamically\nprovision the agentgateway data plane. Labels and annotations that apply to\nall resources may be specified at a higher level; see\nhttps://gateway-api.sigs.k8s.io/reference/spec/#gatewayinfrastructure",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of AgentgatewayParameters.",
+      "properties": {
+        "deployment": {
+          "description": "`deployment` allows specifying overrides for the generated\n`Deployment` resource.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object"
+        },
+        "env": {
+          "description": "The container environment variables. These override any existing\nvalues. If you want to delete an environment variable entirely, use\n`$patch: delete` with `AgentgatewayParametersOverlays` instead. Note that\n[variable\nexpansion](https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/)\ndoes apply, but is highly discouraged -- to set dependent environment\nvariables, you can use `$(VAR_NAME)`, but it's highly discouraged.\n`$$(VAR_NAME)` avoids expansion and results in a literal\n`$(VAR_NAME)`.\n\nIf `SESSION_KEY` is specified, it takes precedence over the\ncontroller-managed per-`Gateway` session key `Secret`.",
+          "items": {
+            "description": "EnvVar represents an environment variable present in a Container.",
+            "properties": {
+              "name": {
+                "description": "Name of the environment variable.\nMay consist of any printable ASCII characters except '='.",
+                "type": "string"
+              },
+              "value": {
+                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                "type": "string"
+              },
+              "valueFrom": {
+                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                "properties": {
+                  "configMapKeyRef": {
+                    "description": "Selects a key of a ConfigMap.",
+                    "properties": {
+                      "key": {
+                        "description": "The key to select.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "fieldRef": {
+                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "Path of the field to select in the specified API version.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "fieldPath"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "fileKeyRef": {
+                    "description": "FileKeyRef selects a key of the env file.\nRequires the EnvFiles feature gate to be enabled.",
+                    "properties": {
+                      "key": {
+                        "description": "The key within the env file. An invalid key will prevent the pod from starting.\nThe keys defined within a source may consist of any printable ASCII characters except '='.\nDuring Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "default": false,
+                        "description": "Specify whether the file or its key must be defined. If the file or key\ndoes not exist, then the env var is not published.\nIf optional is set to true and the specified key does not exist,\nthe environment variable will not be set in the Pod's containers.\n\nIf optional is set to false and the specified key does not exist,\nan error will be returned during Pod creation.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "The path within the volume from which to select the file.\nMust be relative and may not contain the '..' path or start with '..'.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "The name of the volume mount containing the env file.",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "key",
+                      "path",
+                      "volumeName"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "resourceFieldRef": {
+                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                    "properties": {
+                      "containerName": {
+                        "description": "Container name: required for volumes, optional for env vars",
+                        "type": "string"
+                      },
+                      "divisor": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "resource": {
+                        "description": "Required: resource to select",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "resource"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "secretKeyRef": {
+                    "description": "Selects a key of a secret in the pod's namespace",
+                    "properties": {
+                      "key": {
+                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret or its key must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "key"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "horizontalPodAutoscaler": {
+          "description": "`horizontalPodAutoscaler` allows creating a `HorizontalPodAutoscaler`\nfor the agentgateway proxy. If absent, no HPA is created. If present, an\nHPA is created with its `scaleTargetRef` automatically configured to\ntarget the agentgateway proxy `Deployment`. The `metadata` and `spec`\nfields from this overlay are applied to the generated HPA.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object"
+        },
+        "image": {
+          "description": "The agentgateway container image. See\nhttps://kubernetes.io/docs/concepts/containers/images\nfor details.\n\nDefault values, which may be overridden individually:\n\n\tregistry: cr.agentgateway.dev\n\trepository: agentgateway\n\ttag: <agentgateway version>\n\tpullPolicy: <omitted, relying on Kubernetes defaults which depend on the tag>",
+          "properties": {
+            "digest": {
+              "description": "The hash digest of the image, e.g. `sha256:12345...`",
+              "type": "string"
+            },
+            "pullPolicy": {
+              "description": "The image pull policy for the container. See\nhttps://kubernetes.io/docs/concepts/containers/images/#image-pull-policy\nfor details.",
+              "type": "string"
+            },
+            "registry": {
+              "description": "The image registry.",
+              "type": "string"
+            },
+            "repository": {
+              "description": "The image repository (name).",
+              "type": "string"
+            },
+            "tag": {
+              "description": "The image tag.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "istio": {
+          "description": "Configure Istio integration. If enabled, Agentgateway can natively connect to Istio enabled pods with mTLS.",
+          "properties": {
+            "additionalTrustDomains": {
+              "description": "Additional SPIFFE trust domains accepted on inbound HBONE connections.\nThe local trust domain is always implicitly included.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "caAddress": {
+              "description": "The address of the Istio CA. If unset, defaults to `https://istiod.istio-system.svc:15012`.",
+              "type": "string"
+            },
+            "trustDomain": {
+              "description": "The Istio trust domain. If not set, defaults to `cluster.local`.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "logging": {
+          "description": "`logging` configuration for Agentgateway. By default, all logs are set to\n`info` level.",
+          "properties": {
+            "format": {
+              "description": "The default logging format is text.",
+              "enum": [
+                "json",
+                "text"
+              ],
+              "type": "string"
+            },
+            "level": {
+              "description": "Logging level in standard `RUST_LOG` syntax, for example `info` (the\ndefault), or a comma-separated per-module setting such as\n`rmcp=warn,hickory_server::server::server_future=off,typespec_client_core::http::policies::logging=warn`.",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "podDisruptionBudget": {
+          "description": "`podDisruptionBudget` allows creating a `PodDisruptionBudget` for the\nagentgateway proxy. If absent, no PDB is created. If present, a PDB is\ncreated with its selector automatically configured to target the\nagentgateway proxy `Deployment`. The `metadata` and `spec` fields from\nthis overlay are applied to the generated PDB.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object"
+        },
+        "rawConfig": {
+          "description": "`rawConfig` provides an opaque mechanism to configure the `agentgateway`\nconfig file. The `agentgateway` binary has a `-f` option to specify a\nconfig file, and this field supplies that file. This will be merged with\nconfiguration derived from typed fields like `logging.format`, and those\ntyped fields will take precedence.\n\nExample:\n\n\trawConfig:\n\t  binds:\n\t  - port: 3000\n\t    listeners:\n\t    - routes:\n\t      - policies:\n\t          cors:\n\t            allowOrigins:\n\t            - \"*\"\n\t            allowHeaders:\n\t            - mcp-protocol-version\n\t            - content-type\n\t            - cache-control\n\t        backends:\n\t        - mcp:\n\t            targets:\n\t            - name: everything\n\t              stdio:\n\t                cmd: npx\n\t                args: [\"@modelcontextprotocol/server-everything\"]",
+          "type": "object",
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "resources": {
+          "description": "The compute resources required by this container. See\nhttps://kubernetes.io/docs/concepts/configuration/manage-resources-containers/\nfor details.",
+          "properties": {
+            "claims": {
+              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis field depends on the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+              "items": {
+                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                "properties": {
+                  "name": {
+                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                    "type": "string"
+                  },
+                  "request": {
+                    "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array",
+              "x-kubernetes-list-map-keys": [
+                "name"
+              ],
+              "x-kubernetes-list-type": "map"
+            },
+            "limits": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              },
+              "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "service": {
+          "description": "`service` allows specifying overrides for the generated `Service`\nresource.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object"
+        },
+        "serviceAccount": {
+          "description": "`serviceAccount` allows specifying overrides for the generated\n`ServiceAccount` resource.",
+          "properties": {
+            "metadata": {
+              "description": "`metadata` defines a subset of object metadata to be customized.\n`labels` and `annotations` are merged with existing values. If both\n`GatewayClass` and `Gateway` parameters define the same label or\nannotation key, the `Gateway` value takes precedence (applied second).",
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be\nset by external tools to store and retrieve arbitrary metadata. They are not\nqueryable and should be preserved when modifying objects.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "spec": {
+              "description": "`spec` provides an opaque mechanism to configure the resource spec.\nThis field accepts a complete or partial Kubernetes resource spec, such\nas `PodSpec` or `ServiceSpec`, and will be merged with the generated\nconfiguration using **Strategic Merge Patch** semantics.\n\n# Application Order\n\nOverlays are applied after all typed configuration fields from both levels.\nThe full merge order is:\n\n 1. `GatewayClass` typed configuration fields\n 2. `Gateway` typed configuration fields\n 3. `GatewayClass` overlays\n 4. `Gateway` overlays (can override all previous values)\n\n# Strategic Merge Patch & Deletion Guide\n\nThis merge strategy allows you to override individual fields, merge lists, or delete items\nwithout needing to provide the entire resource definition.\n\n**1. Replacing Values (Scalars):**\nSimple fields (strings, integers, booleans) in your config will overwrite the generated defaults.\n\n**2. Merging Lists (Append/Merge):**\nLists with \"merge keys\", like `containers` which merges on `name`, or\n`tolerations` which merges on `key`,\nwill append your items to the generated list, or update existing items if keys match.\n\n**3. Deleting Fields or List Items ($patch: delete):**\nTo remove a field or list item from the generated resource, use the\n`$patch: delete` directive. This works for both map fields and list items,\nand is the recommended approach because it works with both client-side\nand server-side apply.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      # Delete pod-level securityContext\n\t      securityContext:\n\t        $patch: delete\n\t      # Delete nodeSelector\n\t      nodeSelector:\n\t        $patch: delete\n\t      containers:\n\t      # Be sure to use the correct proxy name here or you will add a\n\t      # container instead of modifying a container.\n\t      - name: proxy-name\n\t        # Delete container-level securityContext\n\t        securityContext:\n\t          $patch: delete\n\n**4. Null Values (server-side apply only):**\nSetting a field to `null` can also remove it, but this ONLY works with\n`kubectl apply --server-side` or equivalent. With regular client-side\n`kubectl apply`, null values are stripped by kubectl before reaching\nthe API server, so the deletion won't occur. Prefer `$patch: delete`\nfor consistent behavior across both apply modes.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector: null  # Removes nodeSelector (server-side apply only!)\n\n**5. Replacing Maps Entirely ($patch: replace):**\nTo replace an entire map with your values (instead of merging), use `$patch: replace`.\nThis removes all existing keys and replaces them with only your specified keys.\n\n\tspec:\n\t  template:\n\t    spec:\n\t      nodeSelector:\n\t        $patch: replace\n\t        custom-key: custom-value\n\n**6. Replacing Lists Entirely ($patch: replace):**\nIf you want to strictly define a list and ignore all generated defaults, use `$patch: replace`.\n\n\tservice:\n\t  spec:\n\t    ports:\n\t    - $patch: replace\n\t    - name: http\n\t      port: 80\n\t      targetPort: 8080\n\t      protocol: TCP\n\t    - name: https\n\t      port: 443\n\t      targetPort: 8443\n\t      protocol: TCP",
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "type": "object"
+        },
+        "shutdown": {
+          "description": "Shutdown delay configuration. How graceful planned or unplanned data\nplane changes happen is in tension with how quickly rollouts of the data\nplane complete. How long a data plane pod must wait for shutdown to be\nperfectly graceful depends on how you have configured your `Gateway`\nresources.",
+          "properties": {
+            "max": {
+              "description": "Maximum time (in seconds) to wait before allowing Agentgateway to\nterminate. Refer to the `TERMINATION_GRACE_PERIOD_SECONDS`\nenvironment variable for details.",
+              "format": "int64",
+              "maximum": 31536000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            "min": {
+              "description": "Minimum time (in seconds) to wait before allowing Agentgateway to\nterminate. Refer to the `CONNECTION_MIN_TERMINATION_DEADLINE`\nenvironment variable for details.",
+              "format": "int64",
+              "maximum": 31536000,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "max",
+            "min"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "The 'min' value must be less than or equal to the 'max' value.",
+              "rule": "self.min <= self.max"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "status": {
+      "description": "status defines the current state of AgentgatewayParameters.",
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/schemas/agentgateway.dev/agentgatewaypolicy_v1alpha1.json
+++ b/schemas/agentgateway.dev/agentgatewaypolicy_v1alpha1.json
@@ -1,0 +1,7663 @@
+{
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec defines the desired state of AgentgatewayPolicy.",
+      "properties": {
+        "backend": {
+          "description": "backend defines settings for how to connect to destination backends.\n\nA backend policy can target a `Gateway` (optionally, with a\n`sectionName` indicating the listener), `ListenerSet`, `Route`\n(optionally, with a `sectionName` indicating the route rule), or a\n`Service` or `Backend` (optionally, with a `sectionName` indicating the\nport for `Service`, or sub-backend for `Backend`).\n\nNote that a backend policy applies when connecting to a specific destination backend. Targeting a higher level\nresource, like `Gateway`, is just a way to easily apply a policy to a\ngroup of backends.\n\nWhen multiple policies are selected for a given request, they are merged on a field-level basis, but not a deep\nmerge. Precedence is given to more precise policies: `Gateway` <\n`Listener` < `Route` < `Route Rule` < `Backend` or `Service`. For\nexample, if a `Gateway` policy sets `tcp` and `tls`, and a `Backend`\npolicy sets `tls`, the effective policy would be `tcp` from the\n`Gateway`, and `tls` from the `Backend`.",
+          "properties": {
+            "ai": {
+              "description": "`ai` specifies settings for AI workloads. This is only applicable when\nconnecting to a `Backend` of type `ai`.",
+              "properties": {
+                "defaults": {
+                  "description": "Provide defaults to merge with user input fields. If the field is already set, the field in the request is used.",
+                  "items": {
+                    "description": "FieldDefault provides default values for specific fields in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                    "properties": {
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "The name of the field.",
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The field default value, which can be any JSON Data Type.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "required": [
+                      "field",
+                      "value"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "modelAliases": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "ModelAliases maps friendly model names to actual provider model names.\nExample: `{\"fast\": \"gpt-3.5-turbo\", \"smart\": \"gpt-4-turbo\"}`.\nNote: This field is only applicable when using the agentgateway data plane.",
+                  "maxProperties": 64,
+                  "type": "object"
+                },
+                "overrides": {
+                  "description": "Provide overrides to merge with user input fields. If the field is already set, the field will be overwritten.",
+                  "items": {
+                    "description": "FieldDefault provides default values for specific fields in the JSON request body sent to the LLM provider.\nThese defaults are merged with the user-provided request to ensure missing fields are populated.\n\nUser input fields here refer to the fields in the JSON request body that a client sends when making a request to the LLM provider.\nDefaults set here do _not_ override those user-provided values unless you explicitly set `override` to `true`.\n\nExample: Setting a default system field for Anthropic, which does not support system role messages:\n\n\tdefaults:\n\t  - field: \"system\"\n\t    value: \"answer all questions in French\"\n\nExample: Setting a default temperature and overriding `max_tokens`:\n\n\tdefaults:\n\t  - field: \"temperature\"\n\t    value: \"0.5\"\n\t  - field: \"max_tokens\"\n\t    value: \"100\"\n\t    override: true\n\nExample: Setting custom lists fields:\n\n\tdefaults:\n\t  - field: \"custom_integer_list\"\n\t    value: [1,2,3]\n\n\toverrides:\n\t  - field: \"custom_string_list\"\n\t    value: [\"one\",\"two\",\"three\"]\n\nNote: The `field` values correspond to keys in the JSON request body, not fields in this CRD.",
+                    "properties": {
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "The name of the field.",
+                        "maxLength": 256,
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "The field default value, which can be any JSON Data Type.",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    },
+                    "required": [
+                      "field",
+                      "value"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "prompt": {
+                  "description": "Enrich requests sent to the LLM provider by appending and prepending system prompts. This can be configured only for\nLLM providers that use the `CHAT` or `CHAT_STREAMING` API route type.",
+                  "properties": {
+                    "append": {
+                      "description": "A list of messages to be appended to the prompt sent by the client.",
+                      "items": {
+                        "description": "An entry for a message to prepend or append to each prompt.",
+                        "properties": {
+                          "content": {
+                            "description": "String content of the message.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "role"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "prepend": {
+                      "description": "A list of messages to be prepended to the prompt sent by the client.",
+                      "items": {
+                        "description": "An entry for a message to prepend or append to each prompt.",
+                        "properties": {
+                          "content": {
+                            "description": "String content of the message.",
+                            "type": "string"
+                          },
+                          "role": {
+                            "description": "Role of the message. The available roles depend on the backend\nLLM provider model, such as `SYSTEM` or `USER` in the OpenAI API.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "content",
+                          "role"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "promptCaching": {
+                  "description": "`promptCaching` enables automatic prompt caching for supported\nproviders, currently AWS Bedrock.\nReduces API costs by caching static content like system prompts and tool definitions.\nOnly applicable for Bedrock Claude 3+ and Nova models.",
+                  "properties": {
+                    "cacheMessageOffset": {
+                      "default": 0,
+                      "description": "CacheMessageOffset shifts the message cache point further back in the\nconversation. 0 (default) places it at the second-to-last message.\nHigher values move it N additional messages towards the start, clamped\nto bounds.",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "cacheMessages": {
+                      "default": true,
+                      "description": "CacheMessages enables caching for conversation messages.\nCaches all messages in the conversation for cost savings.",
+                      "type": "boolean"
+                    },
+                    "cacheSystem": {
+                      "default": true,
+                      "description": "CacheSystem enables caching for system prompts.\nInserts a cache point after all system messages.",
+                      "type": "boolean"
+                    },
+                    "cacheTools": {
+                      "default": false,
+                      "description": "CacheTools enables caching for tool definitions.\nInserts a cache point after all tool specifications.",
+                      "type": "boolean"
+                    },
+                    "minTokens": {
+                      "default": 1024,
+                      "description": "MinTokens specifies the minimum estimated token count\nbefore caching is enabled. Uses rough heuristic (word count × 1.3) to estimate tokens.\nBedrock requires at least 1,024 tokens for caching to be effective.",
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "promptGuard": {
+                  "description": "`promptGuard` enables adding guardrails to LLM requests and responses.",
+                  "properties": {
+                    "request": {
+                      "description": "Prompt guards to apply to requests sent by the client.",
+                      "items": {
+                        "description": "PromptguardRequest defines the prompt guards to apply to requests sent by the client.",
+                        "properties": {
+                          "bedrockGuardrails": {
+                            "description": "`bedrockGuardrails` configures AWS Bedrock Guardrails for prompt\nguarding.",
+                            "properties": {
+                              "identifier": {
+                                "description": "GuardrailIdentifier is the identifier of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "region": {
+                                "description": "Region is the AWS region where the guardrail is deployed (for example,\n`us-west-2`).",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "version": {
+                                "description": "GuardrailVersion is the version of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "identifier",
+                              "region",
+                              "version"
+                            ],
+                            "type": "object"
+                          },
+                          "googleModelArmor": {
+                            "description": "`googleModelArmor` configures Google Model Armor for prompt guarding.",
+                            "properties": {
+                              "location": {
+                                "default": "us-central1",
+                                "description": "Location is the Google Cloud location (for example, `us-central1`).\nDefaults to `us-central1` if not specified.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with Google Model Armor.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projectId": {
+                                "description": "ProjectID is the Google Cloud project ID.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "templateId": {
+                                "description": "TemplateID is the template ID for Google Model Armor.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "projectId",
+                              "templateId"
+                            ],
+                            "type": "object"
+                          },
+                          "openAIModeration": {
+                            "description": "`openAIModeration` passes prompt data through the OpenAI Moderations\nendpoint.\nSee https://developers.openai.com/api/reference/resources/moderations for more information.",
+                            "properties": {
+                              "model": {
+                                "description": "`model` specifies the moderation model to use. For example,\n`omni-moderation`.",
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with OpenAI.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "regex": {
+                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                            "properties": {
+                              "action": {
+                                "default": "Mask",
+                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                "enum": [
+                                  "Mask",
+                                  "Reject"
+                                ],
+                                "type": "string"
+                              },
+                              "builtins": {
+                                "description": "A list of built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                  "enum": [
+                                    "Ssn",
+                                    "CreditCard",
+                                    "PhoneNumber",
+                                    "Email",
+                                    "CaSin"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matches": {
+                                "description": "A list of regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "maxLength": 1024,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "response": {
+                            "description": "A custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                            "properties": {
+                              "message": {
+                                "default": "The request was rejected due to inappropriate content",
+                                "description": "A custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                "type": "string"
+                              },
+                              "statusCode": {
+                                "default": 403,
+                                "description": "The status code to return to the client. Defaults to 403.",
+                                "format": "int32",
+                                "maximum": 599,
+                                "minimum": 200,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [message statusCode] must be set",
+                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                              }
+                            ]
+                          },
+                          "webhook": {
+                            "description": "Configure a webhook to forward requests to for prompt guarding.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "backendRef references the webhook server to reach.\n\nSupported types: Service and Backend.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ]
+                              },
+                              "forwardHeaderMatches": {
+                                "description": "ForwardHeaderMatches defines a list of HTTP header matches that will be\nused to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                "items": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [regex webhook openAIModeration bedrockGuardrails googleModelArmor] must be set",
+                            "rule": "[has(self.regex),has(self.webhook),has(self.openAIModeration),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                          }
+                        ]
+                      },
+                      "maxItems": 8,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "response": {
+                      "description": "Prompt guards to apply to responses returned by the LLM provider.",
+                      "items": {
+                        "description": "PromptguardResponse configures the response that the prompt guard applies to responses returned by the LLM provider.",
+                        "properties": {
+                          "bedrockGuardrails": {
+                            "description": "`bedrockGuardrails` configures AWS Bedrock Guardrails for prompt\nguarding.",
+                            "properties": {
+                              "identifier": {
+                                "description": "GuardrailIdentifier is the identifier of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with AWS Bedrock Guardrails.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "region": {
+                                "description": "Region is the AWS region where the guardrail is deployed (for example,\n`us-west-2`).",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "version": {
+                                "description": "GuardrailVersion is the version of the Guardrail policy to use for the backend.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "identifier",
+                              "region",
+                              "version"
+                            ],
+                            "type": "object"
+                          },
+                          "googleModelArmor": {
+                            "description": "`googleModelArmor` configures Google Model Armor for prompt guarding.",
+                            "properties": {
+                              "location": {
+                                "default": "us-central1",
+                                "description": "Location is the Google Cloud location (for example, `us-central1`).\nDefaults to `us-central1` if not specified.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "policies": {
+                                "description": "policies controls policies for communicating with Google Model Armor.",
+                                "properties": {
+                                  "auth": {
+                                    "description": "`auth` defines settings for managing authentication to the backend.",
+                                    "properties": {
+                                      "aws": {
+                                        "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "required": [
+                                          "secretRef"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "azure": {
+                                        "description": "Azure specifies an Azure authentication method for the backend.",
+                                        "properties": {
+                                          "managedIdentity": {
+                                            "description": "Details for managed identity authentication",
+                                            "properties": {
+                                              "clientId": {
+                                                "type": "string"
+                                              },
+                                              "objectId": {
+                                                "type": "string"
+                                              },
+                                              "resourceId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "clientId",
+                                              "objectId",
+                                              "resourceId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcp": {
+                                        "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                                        "properties": {
+                                          "audience": {
+                                            "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                                            "maxLength": 256,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                                            "properties": {
+                                              "name": {
+                                                "default": "",
+                                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "type": {
+                                            "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                                            "enum": [
+                                              "AccessToken",
+                                              "IdToken"
+                                            ],
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "audience is only valid with IdToken",
+                                            "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                                          }
+                                        ]
+                                      },
+                                      "key": {
+                                        "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                      },
+                                      "location": {
+                                        "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                                        "properties": {
+                                          "cookie": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "header": {
+                                            "properties": {
+                                              "name": {
+                                                "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                                "type": "string"
+                                              },
+                                              "prefix": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          "queryParameter": {
+                                            "properties": {
+                                              "name": {
+                                                "maxLength": 256,
+                                                "minLength": 1,
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "name"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                                            "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                                          }
+                                        ]
+                                      },
+                                      "passthrough": {
+                                        "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                                        "type": "object"
+                                      },
+                                      "secretRef": {
+                                        "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                                        "properties": {
+                                          "name": {
+                                            "default": "",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "location may only be set for key or passthrough auth",
+                                        "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                                      },
+                                      {
+                                        "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                                        "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                                      }
+                                    ]
+                                  },
+                                  "http": {
+                                    "description": "http defines settings for managing HTTP requests to the backend.",
+                                    "properties": {
+                                      "requestTimeout": {
+                                        "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "requestTimeout must be at least 1ms",
+                                            "rule": "duration(self) >= duration('1ms')"
+                                          }
+                                        ]
+                                      },
+                                      "version": {
+                                        "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                                        "enum": [
+                                          "HTTP1",
+                                          "HTTP2"
+                                        ],
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tcp": {
+                                    "description": "tcp defines settings for managing TCP connections to the backend.",
+                                    "properties": {
+                                      "connectTimeout": {
+                                        "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                                        "type": "string",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "invalid duration value",
+                                            "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                          },
+                                          {
+                                            "message": "connectTimeout must be at least 100ms",
+                                            "rule": "duration(self) >= duration('100ms')"
+                                          }
+                                        ]
+                                      },
+                                      "keepalive": {
+                                        "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                                        "properties": {
+                                          "interval": {
+                                            "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "interval must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          },
+                                          "retries": {
+                                            "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                                            "format": "int32",
+                                            "maximum": 64,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          },
+                                          "time": {
+                                            "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                                            "type": "string",
+                                            "x-kubernetes-validations": [
+                                              {
+                                                "message": "invalid duration value",
+                                                "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                              },
+                                              {
+                                                "message": "time must be at least 1 second",
+                                                "rule": "duration(self) >= duration('1s')"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "tls": {
+                                    "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+                                    "properties": {
+                                      "alpnProtocols": {
+                                        "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                                        "items": {
+                                          "maxLength": 64,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      },
+                                      "caCertificateRefs": {
+                                        "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "insecureSkipVerify": {
+                                        "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                                        "enum": [
+                                          "All",
+                                          "Hostname"
+                                        ],
+                                        "type": "string"
+                                      },
+                                      "keyExchangeGroups": {
+                                        "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                                        "items": {
+                                          "enum": [
+                                            "X25519",
+                                            "P-256",
+                                            "P-384",
+                                            "X25519_MLKEM768"
+                                          ],
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mtlsCertificateRef": {
+                                        "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                                        "items": {
+                                          "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                                          "properties": {
+                                            "name": {
+                                              "default": "",
+                                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "maxItems": 1,
+                                        "type": "array",
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "sni": {
+                                        "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                                        "maxLength": 253,
+                                        "minLength": 1,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                        "type": "string"
+                                      },
+                                      "verifySubjectAltNames": {
+                                        "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                                        "items": {
+                                          "maxLength": 256,
+                                          "minLength": 1,
+                                          "type": "string"
+                                        },
+                                        "maxItems": 16,
+                                        "minItems": 1,
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "x-kubernetes-validations": [
+                                      {
+                                        "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                                      },
+                                      {
+                                        "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                                        "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                                      },
+                                      {
+                                        "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                                        "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                                      }
+                                    ]
+                                  },
+                                  "tunnel": {
+                                    "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+                                    "properties": {
+                                      "backendRef": {
+                                        "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                                        "properties": {
+                                          "group": {
+                                            "default": "",
+                                            "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                            "maxLength": 253,
+                                            "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "default": "Service",
+                                            "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name is the name of the referent.",
+                                            "maxLength": 253,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                            "maxLength": 63,
+                                            "minLength": 1,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                            "format": "int32",
+                                            "maximum": 65535,
+                                            "minimum": 1,
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "required": [
+                                          "name"
+                                        ],
+                                        "type": "object",
+                                        "x-kubernetes-validations": [
+                                          {
+                                            "message": "Must have port for Service reference",
+                                            "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "backendRef"
+                                    ],
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "projectId": {
+                                "description": "ProjectID is the Google Cloud project ID.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "templateId": {
+                                "description": "TemplateID is the template ID for Google Model Armor.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "projectId",
+                              "templateId"
+                            ],
+                            "type": "object"
+                          },
+                          "regex": {
+                            "description": "Regular expression (regex) matching for prompt guards and data masking.",
+                            "properties": {
+                              "action": {
+                                "default": "Mask",
+                                "description": "The action to take if a regex pattern is matched in a request or response.\nThis setting applies only to request matches. `PromptguardResponse`\nmatches are always masked by default.\nDefaults to `Mask`.",
+                                "enum": [
+                                  "Mask",
+                                  "Reject"
+                                ],
+                                "type": "string"
+                              },
+                              "builtins": {
+                                "description": "A list of built-in regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "description": "Built-in regex patterns for specific types of strings in prompts.\nFor example, if you specify `CreditCard`, any credit card numbers\nin the request or response are matched.",
+                                  "enum": [
+                                    "Ssn",
+                                    "CreditCard",
+                                    "PhoneNumber",
+                                    "Email",
+                                    "CaSin"
+                                  ],
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "matches": {
+                                "description": "A list of regex patterns to match against the request or response.\nMatches and built-ins are additive.",
+                                "items": {
+                                  "maxLength": 1024,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "response": {
+                            "description": "A custom response message to return to the client. If not specified, defaults to\n`The response was rejected due to inappropriate content`.",
+                            "properties": {
+                              "message": {
+                                "default": "The request was rejected due to inappropriate content",
+                                "description": "A custom response message to return to the client. If not specified, defaults to\n`The request was rejected due to inappropriate content`.",
+                                "type": "string"
+                              },
+                              "statusCode": {
+                                "default": 403,
+                                "description": "The status code to return to the client. Defaults to 403.",
+                                "format": "int32",
+                                "maximum": 599,
+                                "minimum": 200,
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [message statusCode] must be set",
+                                "rule": "[has(self.message),has(self.statusCode)].filter(x,x==true).size() >= 1"
+                              }
+                            ]
+                          },
+                          "webhook": {
+                            "description": "Configure a webhook to forward responses to for prompt guarding.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "backendRef references the webhook server to reach.\n\nSupported types: Service and Backend.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ]
+                              },
+                              "forwardHeaderMatches": {
+                                "description": "ForwardHeaderMatches defines a list of HTTP header matches that will be\nused to select the headers to forward to the webhook.\nRequest headers are used when forwarding requests and response headers\nare used when forwarding responses.\nBy default, no headers are forwarded.",
+                                "items": {
+                                  "description": "HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request\nheaders.",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, only the first\nentry with an equivalent name MUST be considered for a match. Subsequent\nentries with an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.\n\nWhen a header is repeated in an HTTP request, it is\nimplementation-specific behavior as to how this is represented.\nGenerally, proxies should follow the guidance from the RFC:\nhttps://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding\nprocessing a repeated header, with special handling for \"Set-Cookie\".",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "default": "Exact",
+                                      "description": "Type specifies how to match against the value of the header.\n\nSupport: Core (Exact)\n\nSupport: Implementation-specific (RegularExpression)\n\nSince RegularExpression HeaderMatchType has implementation-specific\nconformance, implementations can support POSIX, PCRE or any other dialects\nof regular expressions. Please read the implementation's documentation to\ndetermine the supported dialect.",
+                                      "enum": [
+                                        "Exact",
+                                        "RegularExpression"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                                      "maxLength": 4096,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "required": [
+                              "backendRef"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [regex webhook bedrockGuardrails googleModelArmor] must be set",
+                            "rule": "[has(self.regex),has(self.webhook),has(self.bedrockGuardrails),has(self.googleModelArmor)].filter(x,x==true).size() == 1"
+                          }
+                        ]
+                      },
+                      "maxItems": 8,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [request response] must be set",
+                      "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                },
+                "routes": {
+                  "additionalProperties": {
+                    "description": "RouteType specifies how the AI gateway should process incoming requests\nbased on the URL path and the API format expected.",
+                    "enum": [
+                      "Completions",
+                      "Messages",
+                      "Models",
+                      "Passthrough",
+                      "Detect",
+                      "Responses",
+                      "AnthropicTokenCount",
+                      "Embeddings",
+                      "Realtime"
+                    ],
+                    "type": "string"
+                  },
+                  "description": "`routes` defines how to identify the type of traffic to handle.\nThe keys are URL path suffixes matched using ends-with comparison, for\nexample `\"/v1/chat/completions\"`.\nThe special `*` wildcard matches any path.\nIf not specified, all traffic defaults to `completions` type.",
+                  "type": "object"
+                },
+                "transformations": {
+                  "description": "Provide CEL transformations to compute and set fields in the request body.\nThe expression result overwrites any existing value for that field.\nThis has a higher priority than `overrides` if both are set for the same\nkey.",
+                  "items": {
+                    "description": "FieldTransformation maps a request JSON field to a CEL expression string.\nThe expression is evaluated against the current request body and its result\nis assigned to the configured field.",
+                    "properties": {
+                      "expression": {
+                        "description": "CEL expression used to compute the field value.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "field": {
+                        "allOf": [
+                          {
+                            "minLength": 1
+                          },
+                          {
+                            "minLength": 1
+                          }
+                        ],
+                        "description": "The name of the field to set.",
+                        "maxLength": 256,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression",
+                      "field"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [defaults modelAliases overrides prompt promptCaching promptGuard routes transformations] must be set",
+                  "rule": "[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "auth": {
+              "description": "`auth` defines settings for managing authentication to the backend.",
+              "properties": {
+                "aws": {
+                  "description": "Auth specifies an explicit AWS authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                  "properties": {
+                    "secretRef": {
+                      "description": "`secretRef` references a Kubernetes `Secret` containing the AWS\ncredentials. The `Secret` must have keys `accessKey`, `secretKey`, and\noptionally `sessionToken`.",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    }
+                  },
+                  "required": [
+                    "secretRef"
+                  ],
+                  "type": "object"
+                },
+                "azure": {
+                  "description": "Azure specifies an Azure authentication method for the backend.",
+                  "properties": {
+                    "managedIdentity": {
+                      "description": "Details for managed identity authentication",
+                      "properties": {
+                        "clientId": {
+                          "type": "string"
+                        },
+                        "objectId": {
+                          "type": "string"
+                        },
+                        "resourceId": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "clientId",
+                        "objectId",
+                        "resourceId"
+                      ],
+                      "type": "object"
+                    },
+                    "secretRef": {
+                      "description": "`secretRef` references a Kubernetes `Secret` containing the Azure\ncredentials. The `Secret` must have keys `clientID`, `tenantID`, and\n`clientSecret`.",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    }
+                  },
+                  "type": "object"
+                },
+                "gcp": {
+                  "description": "Auth specifies to use a Google  authentication method for the backend.\nWhen omitted, we will try to use the default AWS SDK authentication methods.",
+                  "properties": {
+                    "audience": {
+                      "description": "`audience` allows explicitly configuring the `aud` of the ID token. Only\nvalid with `IdToken` type. If not set, the `aud` is automatically\nderived from the backend hostname.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "secretRef": {
+                      "description": "`secretRef` references a Kubernetes `Secret` containing ADC-compatible\nGoogle credential JSON in the `credentials.json` key. When omitted,\nambient credentials are used.",
+                      "properties": {
+                        "name": {
+                          "default": "",
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "type": {
+                      "description": "The type of token to generate. To authenticate to GCP services,\ngenerally an `AccessToken` is used. To authenticate to Cloud Run, an\n`IdToken` is used.",
+                      "enum": [
+                        "AccessToken",
+                        "IdToken"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "audience is only valid with IdToken",
+                      "rule": "has(self.audience) ? self.type == 'IdToken' : true"
+                    }
+                  ]
+                },
+                "key": {
+                  "description": "`key` provides an inline key to use as the value of the\n`Authorization` header. This option is the least secure; usage of a\n`Secret` is preferred.",
+                  "maxLength": 2048,
+                  "type": "string"
+                },
+                "location": {
+                  "description": "`location` controls where  backend credentials are inserted.\nIf omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.\nThis applies to `key`, `secretRef`, and `passthrough`.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                    }
+                  ]
+                },
+                "passthrough": {
+                  "description": "`passthrough` passes through an existing token that has been sent by the\nclient and validated. Other policies, like JWT and API key\nauthentication, will strip the original client credentials. Passthrough backend authentication\ncauses the original token to be added back into the request. If there are no client authentication policies on the\nrequest, the original token would be unchanged, so this would have no effect.",
+                  "type": "object"
+                },
+                "secretRef": {
+                  "description": "`secretRef` references a Kubernetes `Secret` storing the key to use as\nthe authorization value. This must be stored in the `Authorization` key.",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "location may only be set for key or passthrough auth",
+                  "rule": "has(self.location) ? has(self.key) || has(self.secretRef) || has(self.passthrough) : true"
+                },
+                {
+                  "message": "exactly one of the fields in [key secretRef passthrough aws azure gcp] must be set",
+                  "rule": "[has(self.key),has(self.secretRef),has(self.passthrough),has(self.aws),has(self.azure),has(self.gcp)].filter(x,x==true).size() == 1"
+                }
+              ]
+            },
+            "extAuth": {
+              "description": "extAuth specifies the external authentication configuration for requests\nsent to this backend.",
+              "properties": {
+                "backendRef": {
+                  "description": "`backendRef` references the External Authorization server to reach.\n\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ]
+                },
+                "failureMode": {
+                  "description": "FailureMode controls behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
+                  "enum": [
+                    "FailOpen",
+                    "FailClosed"
+                  ],
+                  "type": "string"
+                },
+                "forwardBody": {
+                  "description": "`forwardBody` configures whether to include the HTTP body in the request.\nIf enabled, the request body will be buffered.",
+                  "properties": {
+                    "maxSize": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "`maxSize` specifies, in bytes, the largest body that will be buffered\nand sent to the authorization server. If the body size is larger than\n`maxSize`, then the request will be rejected with a response.",
+                      "maxLength": 32,
+                      "minLength": 1,
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true,
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "value must be at least 1 byte and fit within uint32",
+                          "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "maxSize"
+                  ],
+                  "type": "object"
+                },
+                "grpc": {
+                  "description": "grpc specifies that the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
+                  "properties": {
+                    "contextExtensions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "`contextExtensions` specifies additional arbitrary key-value pairs to\nsend to the authorization server in the `context_extensions` field.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "requestMetadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`requestMetadata` specifies metadata to be sent to the authorization\nserver. This maps to the `metadata_context.filter_metadata` field of the\nrequest, and allows dynamic CEL expressions. If unset, by default the\n`envoy.filters.http.jwt_authn` key is set if the JWT policy is used as\nwell, for compatibility.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "http": {
+                  "description": "`http` specifies that the HTTP protocol should be used for connecting to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
+                  "properties": {
+                    "addRequestHeaders": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`addRequestHeaders` specifies what additional headers to add to the\nrequest to the authorization server. While `allowedRequestHeaders` just\npasses the original headers through, `addRequestHeaders` allows defining\ncustom headers based on CEL expressions.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "allowedRequestHeaders": {
+                      "description": "`allowedRequestHeaders` specifies what additional headers from the client request\nwill be sent to the authorization server.\n\nIf unset, the following headers are sent by default: `Authorization`.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "allowedResponseHeaders": {
+                      "description": "`allowedResponseHeaders` specifies what headers from the authorization response\nwill be copied into the request to the backend.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "path": {
+                      "description": "`path` specifies the path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "redirect": {
+                      "description": "`redirect` defines an optional expression to determine a path to\nredirect to on authorization failure. This is useful to redirect to a\nsign-in page.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "responseMetadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`responseMetadata` specifies what metadata fields should be constructed\nfrom the authorization response. These will be included under the\n`extauthz` variable in future CEL expressions. Setting this is useful\nfor things like logging usernames, without needing to include them as\nheaders to the backend, as `allowedResponseHeaders` would.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "health": {
+              "description": "health defines settings for passive and active health checking.",
+              "properties": {
+                "eviction": {
+                  "description": "Eviction defines settings for evicting unhealthy backends.",
+                  "properties": {
+                    "consecutiveFailures": {
+                      "description": "ConsecutiveFailures is the number of consecutive unhealthy responses required before the backend is evicted.\nFor example, a value of 5 means the backend must receive 5 unhealthy responses in a row before being evicted.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response can trigger eviction.",
+                      "format": "int32",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "duration": {
+                      "default": "3s",
+                      "description": "Duration specifies the base time a backend should be evicted after being marked unhealthy.\nSubsequent evictions use multiplicative backoff (duration * times_evicted).\nIf all endpoints are evicted, the load balancer falls back to returning evicted endpoints\nrather than failing entirely.\nIf unset, defaults to `3s`.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "evictionDuration must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "healthThreshold": {
+                      "description": "HealthThreshold is the EWMA (exponentially-weighted moving average) health score threshold, expressed as 0–100.\nWhen set, a backend is only evicted if its computed health drops below this value after an unhealthy response.\nFor example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.\nUnlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average\nso a single success in a stream of failures can delay eviction.\nWhen both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.\nWhen neither is set, a single unhealthy response triggers eviction.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "restoreHealth": {
+                      "description": "RestoreHealth is the health score (0–100) assigned to a backend when it returns from eviction.\nFor gradual recovery, set below 100; for full recovery immediately, set 100.\nIf unset, the backend resumes with the health it had when evicted.",
+                      "format": "int32",
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "type": "object"
+                },
+                "unhealthyCondition": {
+                  "description": "UnhealthyCondition is a CEL expression that determines whether a response indicates an unhealthy backend.\nWhen the expression evaluates to true, the backend is considered unhealthy and may be evicted.\n\nFor example, to evict on 5xx responses: `response.code >= 500`.\n\nWhen unset, any 5xx response, or a connection failure, is treated as unhealthy.\nThis default lowers the backend's health score but does not trigger eviction on its own.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "http": {
+              "description": "http defines settings for managing HTTP requests to the backend.",
+              "properties": {
+                "requestTimeout": {
+                  "description": "requestTimeout specifies the deadline for receiving a response from the backend.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "requestTimeout must be at least 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
+                },
+                "version": {
+                  "description": "`version` specifies the HTTP protocol version to use when connecting to\nthe backend.\nIf not specified, the version is automatically determined:\n* `Service` types can specify it with `appProtocol` on the `Service`\n  port.\n* If traffic is identified as gRPC, `HTTP2` is used.\n* If the incoming traffic was plaintext HTTP, the original protocol will\n  be used.\n* If the incoming traffic was HTTPS, `HTTP1` will be used. This is\n  because most clients will transparently upgrade HTTPS traffic to\n  `HTTP2`, even if the backend doesn't support it.",
+                  "enum": [
+                    "HTTP1",
+                    "HTTP2"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "mcp": {
+              "description": "`mcp` specifies settings for MCP workloads. This is only applicable when\nconnecting to a `Backend` of type `mcp`.",
+              "properties": {
+                "authentication": {
+                  "description": "`authentication` defines `MCPBackend`-specific authentication rules.\n\nThis field is deprecated; prefer to use traffic policy `jwtAuthentication.mcp`, which ensures authentication runs before\nother policies such as transformation and rate limiting.",
+                  "properties": {
+                    "audiences": {
+                      "description": "`audiences` specifies the list of allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "issuer": {
+                      "description": "`issuer` identifies the IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "jwks": {
+                      "description": "`jwks` defines the remote JSON Web Key used to validate the signature of\nthe JWT.",
+                      "properties": {
+                        "backendRef": {
+                          "description": "`backendRef` references the remote JWKS server to reach.\nSupported types are `Service` and static `Backend`. An\n`AgentgatewayPolicy` containing backend TLS config can then be attached\nto the `Service` or `Backend` in order to set TLS options for a\nconnection to the remote `jwks` source.",
+                          "properties": {
+                            "group": {
+                              "default": "",
+                              "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                              "maxLength": 253,
+                              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                              "type": "string"
+                            },
+                            "kind": {
+                              "default": "Service",
+                              "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "Name is the name of the referent.",
+                              "maxLength": 253,
+                              "minLength": 1,
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                              "maxLength": 63,
+                              "minLength": 1,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                              "format": "int32",
+                              "maximum": 65535,
+                              "minimum": 1,
+                              "type": "integer"
+                            }
+                          },
+                          "required": [
+                            "name"
+                          ],
+                          "type": "object",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Must have port for Service reference",
+                              "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                            }
+                          ]
+                        },
+                        "cacheDuration": {
+                          "default": "5m",
+                          "type": "string",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "invalid duration value",
+                              "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                            },
+                            {
+                              "message": "cacheDuration must be at least 5m.",
+                              "rule": "duration(self) >= duration('5m')"
+                            }
+                          ]
+                        },
+                        "jwksPath": {
+                          "description": "Path to the IdP `jwks` endpoint, relative to the root, commonly\n`\".well-known/jwks.json\"`.",
+                          "maxLength": 2000,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "backendRef",
+                        "jwksPath"
+                      ],
+                      "type": "object"
+                    },
+                    "mode": {
+                      "default": "Strict",
+                      "description": "`mode` is the validation mode for JWT authentication.",
+                      "enum": [
+                        "Strict",
+                        "Optional",
+                        "Permissive"
+                      ],
+                      "type": "string"
+                    },
+                    "provider": {
+                      "description": "`provider` specifies the identity provider to use for authentication.",
+                      "enum": [
+                        "Auth0",
+                        "Keycloak"
+                      ],
+                      "type": "string"
+                    },
+                    "resourceMetadata": {
+                      "additionalProperties": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "description": "ResourceMetadata defines the metadata to use for MCP resources.",
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "jwks"
+                  ],
+                  "type": "object"
+                },
+                "authorization": {
+                  "description": "authorization defines MCPBackend level authorization. Unlike authorization at the HTTP level, which will reject\nunauthorized requests with a `403` error, this policy works at the\n`MCPBackend` level.\n\nList operations, such as `list_tools`, will have each item evaluated.\nItems that do not meet the rule will be filtered.\n\nGet or call operations, such as `call_tool`, will evaluate the specific\nitem and reject requests that do not meet the rule.",
+                  "properties": {
+                    "action": {
+                      "default": "Allow",
+                      "description": "`action` defines whether the rule allows, denies, or requires the request if\nmatched. If unspecified, the default is `Allow`.\nRequire policies are conjunctive across merged policies: all require policies must match.",
+                      "enum": [
+                        "Allow",
+                        "Deny",
+                        "Require"
+                      ],
+                      "type": "string"
+                    },
+                    "policy": {
+                      "description": "`policy` specifies the authorization rule to evaluate.\n\n* For `Allow` rules: any policy allows the request.\n* For `Require` rules: all policies must match for the request to be allowed.\n* For `Deny` rules: any matching policy denies the request. Note: a CEL expression that fails to evaluate is not\nconsidered to match, making this a risky policy; prefer to use `Require`.\n\nThe presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.\nWith no rules, all requires are allowed.",
+                      "properties": {
+                        "matchExpressions": {
+                          "description": "MatchExpressions defines a set of conditions that must be satisfied for the rule to match.\nThese expressions should be in the form of a Common Expression Language\n(`CEL`) expression.",
+                          "items": {
+                            "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "maxItems": 256,
+                          "minItems": 1,
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "matchExpressions"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "policy"
+                  ],
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [authentication authorization] must be set",
+                  "rule": "[has(self.authentication),has(self.authorization)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "tcp": {
+              "description": "tcp defines settings for managing TCP connections to the backend.",
+              "properties": {
+                "connectTimeout": {
+                  "description": "`connectTimeout` defines the deadline for establishing a connection to\nthe destination.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "connectTimeout must be at least 100ms",
+                      "rule": "duration(self) >= duration('100ms')"
+                    }
+                  ]
+                },
+                "keepalive": {
+                  "description": "`keepAlive` defines settings for enabling TCP keepalives on the\nconnection.",
+                  "properties": {
+                    "interval": {
+                      "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "interval must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "retries": {
+                      "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                      "format": "int32",
+                      "maximum": 64,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "time": {
+                      "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "time must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "tls": {
+              "description": "tls defines settings for managing TLS connections to the backend.\n\nIf this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to\nvalidate the server, and the SNI will automatically be set based on the destination.",
+              "properties": {
+                "alpnProtocols": {
+                  "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                  "items": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "caCertificateRefs": {
+                  "description": "`caCertificateRefs` defines the CA certificate `ConfigMap` to use to\nverify the server certificate.\nIf unset, the system's trusted certificates are used.",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "insecureSkipVerify": {
+                  "description": "insecureSkipVerify originates TLS but skips verification of the backend's certificate.\nWARNING: This is an insecure option that should only be used if the risks are understood.\n\nThere are two modes:\n* `All` disables all TLS verification.\n* `Hostname` verifies the CA certificate is trusted, but ignores any\n  mismatch of hostname or SANs. Note that this method is still insecure;\n  prefer setting `verifySubjectAltNames` to customize the valid hostnames\n  if possible.",
+                  "enum": [
+                    "All",
+                    "Hostname"
+                  ],
+                  "type": "string"
+                },
+                "keyExchangeGroups": {
+                  "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS connection.\nFor example: `X25519_MLKEM768,X25519`.",
+                  "items": {
+                    "enum": [
+                      "X25519",
+                      "P-256",
+                      "P-384",
+                      "X25519_MLKEM768"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "mtlsCertificateRef": {
+                  "description": "`mtlsCertificateRef` enables mutual TLS to the backend, using the\nspecified key (`tls.key`) and cert (`tls.crt`) from the referenced\n`Secret`.\n\nAn optional `ca.cert` field, if present, will be used to verify the\nserver certificate. If `caCertificateRefs` is also specified, the\n`caCertificateRefs` field takes priority.\n\nIf unspecified, no client certificate will be used.",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                    "properties": {
+                      "name": {
+                        "default": "",
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "maxItems": 1,
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "sni": {
+                  "description": "`sni` specifies the Server Name Indicator (`SNI`) to be used in the TLS\nhandshake. If unset, the `SNI` is automatically set based on the\ndestination hostname.",
+                  "maxLength": 253,
+                  "minLength": 1,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                  "type": "string"
+                },
+                "verifySubjectAltNames": {
+                  "description": "`verifySubjectAltNames` specifies the Subject Alternative Names (`SAN`)\nto verify in the server certificate.\nIf not present, the destination hostname is automatically used.",
+                  "items": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "insecureSkipVerify All and caCertificateRefs may not be set together",
+                  "rule": "has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true"
+                },
+                {
+                  "message": "insecureSkipVerify and verifySubjectAltNames may not be set together",
+                  "rule": "has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true"
+                },
+                {
+                  "message": "at most one of the fields in [verifySubjectAltNames insecureSkipVerify] may be set",
+                  "rule": "[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size() <= 1"
+                }
+              ]
+            },
+            "transformation": {
+              "description": "transformation is used to mutate and transform requests and responses sent to and from the backend.",
+              "properties": {
+                "request": {
+                  "description": "`request` is used to modify the request path.",
+                  "properties": {
+                    "add": {
+                      "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "`body` controls manipulation of the HTTP body.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "An HTTP Header Name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "`set` is a list of headers and the value they should be set to.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                },
+                "response": {
+                  "description": "`response` is used to modify the response path.",
+                  "properties": {
+                    "add": {
+                      "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "`body` controls manipulation of the HTTP body.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "An HTTP Header Name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "`set` is a list of headers and the value they should be set to.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [request response] must be set",
+                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "tunnel": {
+              "description": "`tunnel` defines settings for managing tunnel connections (with behavior like `HTTPS_PROXY`) to the backend.",
+              "properties": {
+                "backendRef": {
+                  "description": "`backendRef` references the proxy server to reach.\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "backendRef"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of the fields in [ai auth extAuth health http mcp tcp tls transformation tunnel] must be set",
+              "rule": "[has(self.ai),has(self.auth),has(self.extAuth),has(self.health),has(self.http),has(self.mcp),has(self.tcp),has(self.tls),has(self.transformation),has(self.tunnel)].filter(x,x==true).size() >= 1"
+            }
+          ]
+        },
+        "frontend": {
+          "description": "frontend defines settings for how to handle incoming traffic.\n\nA frontend policy can only target a `Gateway`. `Listener` and\n`ListenerSet` are not valid targets.\n\nWhen multiple policies are selected for a given request, they are merged on a field-level basis, but not a deep\nmerge. For example, policy A sets `tcp` and `tls`, and policy B sets\n`tls`; the effective policy would be `tcp` from policy A, and `tls` from\npolicy B.",
+          "properties": {
+            "accessLog": {
+              "description": "`accessLog` contains access logging configuration.",
+              "properties": {
+                "attributes": {
+                  "description": "`attributes` specifies customizations to the key-value pairs that are\nlogged.",
+                  "properties": {
+                    "add": {
+                      "description": "`add` specifies additional key-value pairs to be added to each entry.\nThe value is a CEL expression. If the CEL expression fails to evaluate,\nthe pair will be excluded.",
+                      "items": {
+                        "properties": {
+                          "expression": {
+                            "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "name": {
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "expression",
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "remove": {
+                      "description": "`remove` lists the default fields that should be removed. For example,\n`http.method`.",
+                      "items": {
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 32,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add remove] must be set",
+                      "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                },
+                "filter": {
+                  "description": "`filter` specifies a CEL expression that is used to filter logs. A log\nwill only be emitted if the expression evaluates to `true`.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "otlp": {
+                  "description": "`otlp` configures OTLP access log export to an\nOpenTelemetry-compatible backend.",
+                  "properties": {
+                    "backendRef": {
+                      "description": "`backendRef` references the OTLP server to send access logs to.\nSupported types: `Service` and `AgentgatewayBackend`.",
+                      "properties": {
+                        "group": {
+                          "default": "",
+                          "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                          "maxLength": 253,
+                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "default": "Service",
+                          "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the referent.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Must have port for Service reference",
+                          "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                        }
+                      ]
+                    },
+                    "path": {
+                      "description": "`path` specifies the OTLP/HTTP path to use. This is only applicable\nwhen `protocol` is `HTTP`. If unset, this defaults to `/v1/logs`.",
+                      "maxLength": 1024,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "default": "GRPC",
+                      "description": "`protocol` specifies the OTLP protocol variant to use.",
+                      "enum": [
+                        "HTTP",
+                        "GRPC"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "backendRef"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "path is only valid with protocol HTTP",
+                      "rule": "!has(self.path) || !has(self.protocol) || self.protocol == 'HTTP'"
+                    },
+                    {
+                      "message": "path must start with /",
+                      "rule": "!has(self.path) || self.path.startsWith('/')"
+                    }
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "http": {
+              "description": "http defines settings on managing incoming HTTP requests.",
+              "properties": {
+                "http1IdleTimeout": {
+                  "description": "`http1IdleTimeout` defines the timeout before an unused connection is\nclosed.\nIf unset, this defaults to 10 minutes.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "http1IdleTimeout must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                },
+                "http1MaxHeaders": {
+                  "description": "`http1MaxHeaders` defines the maximum number of headers that are allowed\nin `HTTP/1.1` requests.\nIf unset, this defaults to 100.",
+                  "format": "int32",
+                  "maximum": 4096,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "http2ConnectionWindowSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "`http2ConnectionWindowSize` indicates the initial window size for\nconnection-level flow control for received data.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "http2FrameSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "`http2FrameSize` sets the maximum frame size to use.\nIf unset, this defaults to `16kb`.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "http2FrameSize must be at least 16384 bytes",
+                      "rule": "!quantity(string(self)).isLessThan(quantity('16384'))"
+                    },
+                    {
+                      "message": "http2FrameSize must be at most 1677215 bytes",
+                      "rule": "!quantity(string(self)).isGreaterThan(quantity('1677215'))"
+                    },
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "http2KeepaliveInterval": {
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "http2KeepaliveInterval must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                },
+                "http2KeepaliveTimeout": {
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "http2KeepaliveTimeout must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                },
+                "http2MaxHeaderSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "`http2MaxHeaderSize` sets the maximum aggregate size of decoded HTTP/2\nrequest headers.\nIf unset, this defaults to `16Ki`.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "http2WindowSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "`http2WindowSize` indicates the initial window size for stream-level flow\ncontrol for received data.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "maxBufferSize": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "`maxBufferSize` defines the maximum HTTP body size that will be buffered\ninto memory.\nBodies will only be buffered for policies which require buffering.\nIf unset, this defaults to `2mb`.",
+                  "maxLength": 32,
+                  "minLength": 1,
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "value must be at least 1 byte and fit within uint32",
+                      "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                    }
+                  ]
+                },
+                "maxConnectionDuration": {
+                  "description": "`maxConnectionDuration` specifies the maximum time a connection is allowed to remain open.\nAfter this duration, the connection is gracefully closed after the current in-flight request completes.\nUseful for ensuring even traffic distribution behind load balancers during scaling events.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "maxConnectionDuration must be at least 1 second",
+                      "rule": "duration(self) >= duration('1s')"
+                    }
+                  ]
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [http1IdleTimeout http1MaxHeaders http2ConnectionWindowSize http2FrameSize http2KeepaliveInterval http2KeepaliveTimeout http2MaxHeaderSize http2WindowSize maxBufferSize maxConnectionDuration] must be set",
+                  "rule": "[has(self.http1IdleTimeout),has(self.http1MaxHeaders),has(self.http2ConnectionWindowSize),has(self.http2FrameSize),has(self.http2KeepaliveInterval),has(self.http2KeepaliveTimeout),has(self.http2MaxHeaderSize),has(self.http2WindowSize),has(self.maxBufferSize),has(self.maxConnectionDuration)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "metrics": {
+              "description": "`metrics` contains custom Prometheus metric label configuration.\nCEL expressions are evaluated per-request and added as labels to all\nPrometheus metrics exposed by agentgateway.",
+              "properties": {
+                "attributes": {
+                  "description": "`attributes` specifies customizations to the labels that are\nadded to Prometheus metrics.",
+                  "properties": {
+                    "add": {
+                      "description": "`add` specifies additional key-value pairs to be added as custom labels\nto all Prometheus metrics. The value is a CEL expression evaluated\nper-request. If the CEL expression fails to evaluate, the label value\nis set to \"unknown\".\n\nWARNING: High-cardinality labels (e.g., per-user IDs) can significantly\nincrease Prometheus storage and memory usage. Prefer low-cardinality\ndimensions like team or environment.",
+                      "items": {
+                        "properties": {
+                          "expression": {
+                            "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "name": {
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "expression",
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add] must be set",
+                      "rule": "[has(self.add)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "attributes"
+              ],
+              "type": "object"
+            },
+            "networkAuthorization": {
+              "description": "networkAuthorization defines CEL authorization on downstream network connections.\n\nThis runs before protocol handling and is intended for L4 access control,\nfor example using `source.address` with `cidr(...).containsIP(...)`.",
+              "properties": {
+                "action": {
+                  "default": "Allow",
+                  "description": "`action` defines whether the rule allows, denies, or requires the request if\nmatched. If unspecified, the default is `Allow`.\nRequire policies are conjunctive across merged policies: all require policies must match.",
+                  "enum": [
+                    "Allow",
+                    "Deny",
+                    "Require"
+                  ],
+                  "type": "string"
+                },
+                "policy": {
+                  "description": "`policy` specifies the authorization rule to evaluate.\n\n* For `Allow` rules: any policy allows the request.\n* For `Require` rules: all policies must match for the request to be allowed.\n* For `Deny` rules: any matching policy denies the request. Note: a CEL expression that fails to evaluate is not\nconsidered to match, making this a risky policy; prefer to use `Require`.\n\nThe presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.\nWith no rules, all requires are allowed.",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "MatchExpressions defines a set of conditions that must be satisfied for the rule to match.\nThese expressions should be in the form of a Common Expression Language\n(`CEL`) expression.",
+                      "items": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 256,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "matchExpressions"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "policy"
+              ],
+              "type": "object"
+            },
+            "proxyProtocol": {
+              "description": "proxyProtocol defines settings for downstream PROXY protocol handling.\n\nIf configured, incoming connections may require a PROXY header before\nnormal protocol handling. This can also be configured to allow both\nPROXY and non-PROXY traffic on the same listener.",
+              "properties": {
+                "mode": {
+                  "default": "Strict",
+                  "description": "mode controls whether PROXY headers are required or optional.\n\nIf unset, this defaults to `Strict`.",
+                  "enum": [
+                    "Strict",
+                    "Optional"
+                  ],
+                  "type": "string"
+                },
+                "version": {
+                  "default": "V2",
+                  "description": "version controls which PROXY protocol version is accepted.\n\nIf unset, this defaults to `V2`.",
+                  "enum": [
+                    "V1",
+                    "V2",
+                    "All"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "tcp": {
+              "description": "tcp defines settings on managing incoming TCP connections.",
+              "properties": {
+                "keepalive": {
+                  "description": "keepalive defines settings for enabling TCP keepalives on the connection.",
+                  "properties": {
+                    "interval": {
+                      "description": "interval specifies the number of seconds between keep-alive probes.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "interval must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    },
+                    "retries": {
+                      "description": "retries specifies the maximum number of keep-alive probes to send before dropping the connection.\nIf unset, this defaults to 9.",
+                      "format": "int32",
+                      "maximum": 64,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "time": {
+                      "description": "time specifies the number of seconds a connection needs to be idle before keep-alive probes start being sent.\nIf unset, this defaults to 180s.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "invalid duration value",
+                          "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                        },
+                        {
+                          "message": "time must be at least 1 second",
+                          "rule": "duration(self) >= duration('1s')"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [keepalive] must be set",
+                  "rule": "[has(self.keepalive)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "tls": {
+              "description": "tls defines settings on managing incoming TLS connections.",
+              "properties": {
+                "alpnProtocols": {
+                  "description": "`alpnProtocols` sets the Application-Layer Protocol Negotiation (`ALPN`)\nvalue to use in the TLS handshake.\n\nIf not present, defaults to `[\"h2\", \"http/1.1\"]`.",
+                  "items": {
+                    "maxLength": 64,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "cipherSuites": {
+                  "description": "CipherSuites configures the list of cipher suites for a TLS listener.\nThe value is a comma-separated list of cipher suites, for example\n`TLS13_AES_256_GCM_SHA384,TLS13_AES_128_GCM_SHA256`.\nUse this in the TLS options field of a TLS listener.",
+                  "items": {
+                    "enum": [
+                      "TLS13_AES_256_GCM_SHA384",
+                      "TLS13_AES_128_GCM_SHA256",
+                      "TLS13_CHACHA20_POLY1305_SHA256",
+                      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+                      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "handshakeTimeout": {
+                  "description": "`handshakeTimeout` specifies the deadline for a TLS handshake to\ncomplete. If unset, this defaults to `15s`.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "handshakeTimeout must be at least 100ms",
+                      "rule": "duration(self) >= duration('100ms')"
+                    }
+                  ]
+                },
+                "keyExchangeGroups": {
+                  "description": "keyExchangeGroups configures the ordered list of key exchange groups for a TLS listener.\nFor example: `X25519_MLKEM768,X25519`.",
+                  "items": {
+                    "enum": [
+                      "X25519",
+                      "P-256",
+                      "P-384",
+                      "X25519_MLKEM768"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "maxProtocolVersion": {
+                  "description": "MaxTLSVersion configures the maximum TLS version to support.",
+                  "enum": [
+                    "1.2",
+                    "1.3"
+                  ],
+                  "type": "string"
+                },
+                "minProtocolVersion": {
+                  "description": "MinTLSVersion configures the minimum TLS version to support.",
+                  "enum": [
+                    "1.2",
+                    "1.3"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [alpnProtocols cipherSuites handshakeTimeout keyExchangeGroups maxProtocolVersion minProtocolVersion] must be set",
+                  "rule": "[has(self.alpnProtocols),has(self.cipherSuites),has(self.handshakeTimeout),has(self.keyExchangeGroups),has(self.maxProtocolVersion),has(self.minProtocolVersion)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "tracing": {
+              "description": "`tracing` contains various settings for the OpenTelemetry tracer.",
+              "properties": {
+                "attributes": {
+                  "description": "`attributes` specifies customizations to the key-value pairs that are\nincluded in the trace.",
+                  "properties": {
+                    "add": {
+                      "description": "`add` specifies additional key-value pairs to be added to each entry.\nThe value is a CEL expression. If the CEL expression fails to evaluate,\nthe pair will be excluded.",
+                      "items": {
+                        "properties": {
+                          "expression": {
+                            "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "name": {
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "expression",
+                          "name"
+                        ],
+                        "type": "object"
+                      },
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "remove": {
+                      "description": "`remove` lists the default fields that should be removed. For example,\n`http.method`.",
+                      "items": {
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 32,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add remove] must be set",
+                      "rule": "[has(self.add),has(self.remove)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                },
+                "backendRef": {
+                  "description": "`backendRef` references the OTLP server to reach.\nSupported types: `Service` and `AgentgatewayBackend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ]
+                },
+                "clientSampling": {
+                  "description": "`clientSampling` is an expression to determine the amount of client\nsampling. Client sampling determines whether to initiate a new trace\nspan if the incoming request does have a trace already. This should\nevaluate to a float between `0.0` and `1.0`, or a boolean (`true` or\n`false`). If unspecified, client sampling is `100%` enabled.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "path": {
+                  "description": "`path` specifies the OTLP path to use. This is only applicable when\n`protocol` is `HTTP`. If unset, this defaults to `/v1/traces`.",
+                  "maxLength": 1024,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "protocol": {
+                  "default": "GRPC",
+                  "description": "`protocol` specifies the OTLP protocol variant to use.",
+                  "enum": [
+                    "HTTP",
+                    "GRPC"
+                  ],
+                  "type": "string"
+                },
+                "randomSampling": {
+                  "description": "`randomSampling` is an expression to determine the amount of random\nsampling. Random sampling will initiate a new trace span if the incoming\nrequest does not have a trace initiated already. This should evaluate to\na float between `0.0` and `1.0`, or a boolean (`true` or `false`). If\nunspecified, random sampling is disabled.",
+                  "maxLength": 16384,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "resources": {
+                  "description": "`resources` describes the entity producing telemetry and specifies the\nresources to be included in the trace.",
+                  "items": {
+                    "properties": {
+                      "expression": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "name": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "expression",
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "backendRef"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "path is only valid with protocol HTTP",
+                  "rule": "!has(self.path) || !has(self.protocol) || self.protocol == 'HTTP'"
+                },
+                {
+                  "message": "path must start with /",
+                  "rule": "!has(self.path) || self.path.startsWith('/')"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of the fields in [accessLog http metrics networkAuthorization proxyProtocol tcp tls tracing] must be set",
+              "rule": "[has(self.accessLog),has(self.http),has(self.metrics),has(self.networkAuthorization),has(self.proxyProtocol),has(self.tcp),has(self.tls),has(self.tracing)].filter(x,x==true).size() >= 1"
+            }
+          ]
+        },
+        "targetRefs": {
+          "description": "`targetRefs` specifies the target resources by reference to attach the\npolicy to.",
+          "items": {
+            "description": "Select the object to attach the policy by `Group`, `Kind`, `Name`, and\n`SectionName`.\nThe object must be in the same namespace as the policy.\nYou can target only one object at a time.",
+            "properties": {
+              "group": {
+                "description": "The API group of the target resource.\nFor Kubernetes Gateway API resources, the group is `gateway.networking.k8s.io`.",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              },
+              "kind": {
+                "description": "The API kind of the target resource, such as `Gateway` or `HTTPRoute`.",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the target resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "type": "string"
+              },
+              "sectionName": {
+                "description": "The section name of the target resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "group",
+              "kind",
+              "name"
+            ],
+            "type": "object"
+          },
+          "maxItems": 16,
+          "minItems": 1,
+          "type": "array",
+          "x-kubernetes-list-type": "atomic",
+          "x-kubernetes-validations": [
+            {
+              "message": "targetRefs may only reference Gateway, HTTPRoute, GRPCRoute, ListenerSet, Service, AgentgatewayBackend, or InferencePool resources",
+              "rule": "self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') || (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group == 'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group == 'gateway.networking.k8s.io') || (r.kind == 'InferencePool' && r.group == 'inference.networking.k8s.io'))"
+            },
+            {
+              "message": "Only one Kind of targetRef can be set on one policy",
+              "rule": "self.all(l1, !self.exists(l2, l1.kind != l2.kind))"
+            }
+          ]
+        },
+        "targetSelectors": {
+          "description": "`targetSelectors` specifies the target selectors used to select resources\nto attach the policy to.",
+          "items": {
+            "description": "LocalPolicyTargetSelectorWithSectionName selects the object to attach the\npolicy by `Group`, `Kind`, `MatchLabels`, and optionally `SectionName`.\nThe object must be in the same namespace as the policy and match the\nspecified labels.\nDo not use `targetSelectors` when reconciliation times are critical,\nespecially if you\nhave a large number of policies that target the same resource.\nInstead, use `targetRefs` to attach the policy.",
+            "properties": {
+              "group": {
+                "description": "The API group of the target resource.\nFor Kubernetes Gateway API resources, the group is `gateway.networking.k8s.io`.",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              },
+              "kind": {
+                "description": "The API kind of the target resource, such as `Gateway` or `HTTPRoute`.",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                "type": "string"
+              },
+              "matchLabels": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Label selector to select the target resource.",
+                "type": "object"
+              },
+              "sectionName": {
+                "description": "The section name of the target resource.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "group",
+              "kind",
+              "matchLabels"
+            ],
+            "type": "object"
+          },
+          "maxItems": 16,
+          "minItems": 1,
+          "type": "array",
+          "x-kubernetes-validations": [
+            {
+              "message": "targetRefs may only reference Gateway, HTTPRoute, GRPCRoute, ListenerSet, Service, AgentgatewayBackend, or InferencePool resources",
+              "rule": "self.all(r, (r.kind == 'Service' && r.group == '') || (r.kind == 'AgentgatewayBackend' && r.group == 'agentgateway.dev') || (r.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute'] && r.group == 'gateway.networking.k8s.io') || (r.kind == 'ListenerSet' && r.group == 'gateway.networking.k8s.io') || (r.kind == 'InferencePool' && r.group == 'inference.networking.k8s.io'))"
+            },
+            {
+              "message": "Only one Kind of targetRef can be set on one policy",
+              "rule": "self.all(l1, !self.exists(l2, l1.kind != l2.kind))"
+            }
+          ]
+        },
+        "traffic": {
+          "description": "traffic defines settings for how process traffic.\n\nA traffic policy can target a `Gateway` (optionally, with a\n`sectionName` indicating the listener), `ListenerSet`, or `Route`\n(optionally, with a `sectionName` indicating the route rule).\n\nWhen multiple policies are selected for a given request, they are merged on a field-level basis, but not a deep\nmerge. Precedence is given to more precise policies: `Gateway` <\n`Listener` < `Route` < `Route Rule`. For example, policy A sets\n`timeouts` and `retries`, and policy B sets `retries`; the effective\npolicy would be `timeouts` from policy A, and `retries` from policy B.",
+          "properties": {
+            "apiKeyAuthentication": {
+              "description": "`apiKeyAuthentication` authenticates users based on a configured API\nkey.",
+              "properties": {
+                "location": {
+                  "description": "`location` controls where API keys are read from.\nIf omitted, credentials are read from the `Authorization` header with the `Bearer ` prefix.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                    }
+                  ]
+                },
+                "mode": {
+                  "default": "Strict",
+                  "description": "`mode` is the validation mode for API key authentication.",
+                  "enum": [
+                    "Strict",
+                    "Optional"
+                  ],
+                  "type": "string"
+                },
+                "secretRef": {
+                  "description": "`secretRef` references a Kubernetes `Secret` storing a set of API keys.\nIf there are many keys, `secretSelector` can be used instead.\n\nEach entry in the `Secret` represents one API key. The key is an\narbitrary identifier. The value can either be:\n* A string representing the API key.\n* A JSON object with two fields, `key` and `metadata`. `key` contains\n  the API key. `metadata` contains arbitrary JSON metadata associated\n  with the key, which may be used by other policies. For example, you\n  may write an authorization policy allowing `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2: \"k-456\"",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "secretSelector": {
+                  "description": "`secretSelector` selects multiple `Secret` resources containing API\nkeys. If the same key is defined in multiple secrets, the behavior is\nundefined.\n\nEach entry in the `Secret` represents one API key. The key is an\narbitrary identifier. The value can either be:\n* A string representing the API key.\n* A JSON object with two fields, `key` and `metadata`. `key` contains\n  the API key. `metadata` contains arbitrary JSON metadata associated\n  with the key, which may be used by other policies. For example, you\n  may write an authorization policy allowing `apiKey.group == 'sales'`.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: api-key\n\tstringData:\n\t  client1: |\n\t    {\n\t      \"key\": \"k-123\",\n\t      \"metadata\": {\n\t        \"group\": \"sales\",\n\t        \"created_at\": \"2024-10-01T12:00:00Z\"\n\t      }\n\t    }\n\t  client2: \"k-456\"",
+                  "properties": {
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Label selector to select the target resource.",
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "matchLabels"
+                  ],
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "exactly one of the fields in [secretRef secretSelector] must be set",
+                  "rule": "[has(self.secretRef),has(self.secretSelector)].filter(x,x==true).size() == 1"
+                }
+              ]
+            },
+            "authorization": {
+              "description": "`authorization` specifies the access rules based on roles and\npermissions.\nIf multiple authorization rules are applied across different policies (at the same, or different, attahcment points),\nall rules are merged.",
+              "properties": {
+                "action": {
+                  "default": "Allow",
+                  "description": "`action` defines whether the rule allows, denies, or requires the request if\nmatched. If unspecified, the default is `Allow`.\nRequire policies are conjunctive across merged policies: all require policies must match.",
+                  "enum": [
+                    "Allow",
+                    "Deny",
+                    "Require"
+                  ],
+                  "type": "string"
+                },
+                "policy": {
+                  "description": "`policy` specifies the authorization rule to evaluate.\n\n* For `Allow` rules: any policy allows the request.\n* For `Require` rules: all policies must match for the request to be allowed.\n* For `Deny` rules: any matching policy denies the request. Note: a CEL expression that fails to evaluate is not\nconsidered to match, making this a risky policy; prefer to use `Require`.\n\nThe presence of at least one `Allow` rule triggers a deny-by-default policy, requiring at least 1 match to allow.\nWith no rules, all requires are allowed.",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "MatchExpressions defines a set of conditions that must be satisfied for the rule to match.\nThese expressions should be in the form of a Common Expression Language\n(`CEL`) expression.",
+                      "items": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 256,
+                      "minItems": 1,
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "matchExpressions"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "policy"
+              ],
+              "type": "object"
+            },
+            "basicAuthentication": {
+              "description": "`basicAuthentication` authenticates users based on the `Basic`\nauthentication scheme (RFC 7617), where a username and password are\nencoded in the request.",
+              "properties": {
+                "location": {
+                  "description": "`location` controls where Basic credentials are read from.\nIf omitted, credentials are read from the `Authorization` header with the `Basic ` prefix.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                    }
+                  ]
+                },
+                "mode": {
+                  "default": "Strict",
+                  "description": "`mode` is the validation mode for basic auth authentication.",
+                  "enum": [
+                    "Strict",
+                    "Optional"
+                  ],
+                  "type": "string"
+                },
+                "realm": {
+                  "description": "`realm` specifies the `realm` to return in the `WWW-Authenticate`\nheader for failed authentication requests. If unset, `Restricted` will\nbe used.",
+                  "type": "string"
+                },
+                "secretRef": {
+                  "description": "`secretRef` references a Kubernetes `Secret` storing the `.htaccess`\nfile. The `Secret` must have a key named `.htaccess`, and should contain\nthe complete `.htaccess` file.\n\nNote: passwords should be the hash of the password, not the raw password. Use the `htpasswd` or similar commands\nto generate a hash. MD5, bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tapiVersion: v1\n\tkind: Secret\n\tmetadata:\n\t  name: basic-auth\n\tstringData:\n\t  .htaccess: |\n\t    alice:$apr1$3zSE0Abt$IuETi4l5yO87MuOrbSE4V.\n\t    bob:$apr1$Ukb5LgRD$EPY2lIfY.A54jzLELNIId/",
+                  "properties": {
+                    "name": {
+                      "default": "",
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "users": {
+                  "description": "`users` provides an inline list of username and password pairs that will\nbe accepted. Each entry represents one line of the `htpasswd` format:\nhttps://httpd.apache.org/docs/2.4/programs/htpasswd.html.\n\nNote: passwords should be the hash of the password, not the raw password. Use the `htpasswd` or similar commands\nto generate a hash. MD5, bcrypt, crypt, and SHA-1 are supported.\n\nExample:\n\n\tusers:\n\t- \"user1:$apr1$ivPt0D4C$DmRhnewfHRSrb3DQC.WHC.\"\n\t- \"user2:$2y$05$r3J4d3VepzFkedkd/q1vI.pBYIpSqjfN0qOARV3ScUHysatnS0cL2\"",
+                  "items": {
+                    "type": "string"
+                  },
+                  "maxItems": 256,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "exactly one of the fields in [users secretRef] must be set",
+                  "rule": "[has(self.users),has(self.secretRef)].filter(x,x==true).size() == 1"
+                }
+              ]
+            },
+            "cors": {
+              "description": "cors specifies the CORS configuration for the policy.",
+              "properties": {
+                "allowCredentials": {
+                  "description": "AllowCredentials indicates whether the actual cross-origin request allows\nto include credentials.\n\nWhen set to true, the gateway will include the `Access-Control-Allow-Credentials`\nresponse header with value true (case-sensitive).\n\nWhen set to false or omitted the gateway will omit the header\n`Access-Control-Allow-Credentials` entirely (this is the standard CORS\nbehavior).\n\nSupport: Extended",
+                  "type": "boolean"
+                },
+                "allowHeaders": {
+                  "description": "AllowHeaders indicates which HTTP request headers are supported for\naccessing the requested resource.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Allow-Headers`\nresponse header are separated by a comma (\",\").\n\nWhen the `AllowHeaders` field is configured with one or more headers, the\ngateway must return the `Access-Control-Allow-Headers` response header\nwhich value is present in the `AllowHeaders` field.\n\nIf any header name in the `Access-Control-Request-Headers` request header\nis not included in the list of header names specified by the response\nheader `Access-Control-Allow-Headers`, it will present an error on the\nclient side.\n\nIf any header name in the `Access-Control-Allow-Headers` response header\ndoes not recognize by the client, it will also occur an error on the\nclient side.\n\nA wildcard indicates that the requests with all HTTP headers are allowed.\nIf config contains the wildcard \"*\" in allowHeaders and the request is\nnot credentialed, the `Access-Control-Allow-Headers` response header\ncan either use the `*` wildcard or the value of\nAccess-Control-Request-Headers from the request.\n\nWhen the request is credentialed, the gateway must not specify the `*`\nwildcard in the `Access-Control-Allow-Headers` response header. When\nalso the `AllowCredentials` field is true and `AllowHeaders` field\nis specified with the `*` wildcard, the gateway must specify one or more\nHTTP headers in the value of the `Access-Control-Allow-Headers` response\nheader. The value of the header `Access-Control-Allow-Headers` is same as\nthe `Access-Control-Request-Headers` header provided by the client. If\nthe header `Access-Control-Request-Headers` is not included in the\nrequest, the gateway will omit the `Access-Control-Allow-Headers`\nresponse header, instead of specifying the `*` wildcard.\n\nSupport: Extended",
+                  "items": {
+                    "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "AllowHeaders cannot contain '*' alongside other methods",
+                      "rule": "!('*' in self && self.size() > 1)"
+                    }
+                  ]
+                },
+                "allowMethods": {
+                  "description": "AllowMethods indicates which HTTP methods are supported for accessing the\nrequested resource.\n\nValid values are any method defined by RFC9110, along with the special\nvalue `*`, which represents all HTTP methods are allowed.\n\nMethod names are case-sensitive, so these values are also case-sensitive.\n(See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)\n\nMultiple method names in the value of the `Access-Control-Allow-Methods`\nresponse header are separated by a comma (\",\").\n\nA CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.\n(See https://fetch.spec.whatwg.org/#cors-safelisted-method) The\nCORS-safelisted methods are always allowed, regardless of whether they\nare specified in the `AllowMethods` field.\n\nWhen the `AllowMethods` field is configured with one or more methods, the\ngateway must return the `Access-Control-Allow-Methods` response header\nwhich value is present in the `AllowMethods` field.\n\nIf the HTTP method of the `Access-Control-Request-Method` request header\nis not included in the list of methods specified by the response header\n`Access-Control-Allow-Methods`, it will present an error on the client\nside.\n\nIf config contains the wildcard \"*\" in allowMethods and the request is\nnot credentialed, the `Access-Control-Allow-Methods` response header\ncan either use the `*` wildcard or the value of\nAccess-Control-Request-Method from the request.\n\nWhen the request is credentialed, the gateway must not specify the `*`\nwildcard in the `Access-Control-Allow-Methods` response header. When\nalso the `AllowCredentials` field is true and `AllowMethods` field\nspecified with the `*` wildcard, the gateway must specify one HTTP method\nin the value of the Access-Control-Allow-Methods response header. The\nvalue of the header `Access-Control-Allow-Methods` is same as the\n`Access-Control-Request-Method` header provided by the client. If the\nheader `Access-Control-Request-Method` is not included in the request,\nthe gateway will omit the `Access-Control-Allow-Methods` response header,\ninstead of specifying the `*` wildcard.\n\nSupport: Extended",
+                  "items": {
+                    "enum": [
+                      "GET",
+                      "HEAD",
+                      "POST",
+                      "PUT",
+                      "DELETE",
+                      "CONNECT",
+                      "OPTIONS",
+                      "TRACE",
+                      "PATCH",
+                      "*"
+                    ],
+                    "type": "string"
+                  },
+                  "maxItems": 9,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "AllowMethods cannot contain '*' alongside other methods",
+                      "rule": "!('*' in self && self.size() > 1)"
+                    }
+                  ]
+                },
+                "allowOrigins": {
+                  "description": "AllowOrigins indicates whether the response can be shared with requested\nresource from the given `Origin`.\n\nThe `Origin` consists of a scheme and a host, with an optional port, and\ntakes the form `<scheme>://<host>(:<port>)`.\n\nValid values for scheme are: `http` and `https`.\n\nValid values for port are any integer between 1 and 65535 (the list of\navailable TCP/UDP ports). Note that, if not included, port `80` is\nassumed for `http` scheme origins, and port `443` is assumed for `https`\norigins. This may affect origin matching.\n\nThe host part of the origin may contain the wildcard character `*`. These\nwildcard characters behave as follows:\n\n* `*` is a greedy match to the _left_, including any number of\n  DNS labels to the left of its position. This also means that\n  `*` will include any number of period `.` characters to the\n  left of its position.\n* A wildcard by itself matches all hosts.\n\nAn origin value that includes _only_ the `*` character indicates requests\nfrom all `Origin`s are allowed.\n\nWhen the `AllowOrigins` field is configured with multiple origins, it\nmeans the server supports clients from multiple origins. If the request\n`Origin` matches the configured allowed origins, the gateway must return\nthe given `Origin` and sets value of the header\n`Access-Control-Allow-Origin` same as the `Origin` header provided by the\nclient.\n\nThe status code of a successful response to a \"preflight\" request is\nalways an OK status (i.e., 204 or 200).\n\nIf the request `Origin` does not match the configured allowed origins,\nthe gateway returns 204/200 response but doesn't set the relevant\ncross-origin response headers. Alternatively, the gateway responds with\n403 status to the \"preflight\" request is denied, coupled with omitting\nthe CORS headers. The cross-origin request fails on the client side.\nTherefore, the client doesn't attempt the actual cross-origin request.\n\nConversely, if the request `Origin` matches one of the configured\nallowed origins, the gateway sets the response header\n`Access-Control-Allow-Origin` to the same value as the `Origin`\nheader provided by the client.\n\nWhen config has the wildcard (\"*\") in allowOrigins, and the request\nis not credentialed (e.g., it is a preflight request), the\n`Access-Control-Allow-Origin` response header either contains the\nwildcard as well or the Origin from the request.\n\nWhen the request is credentialed, the gateway must not specify the `*`\nwildcard in the `Access-Control-Allow-Origin` response header. When\nalso the `AllowCredentials` field is true and `AllowOrigins` field\nspecified with the `*` wildcard, the gateway must return a single origin\nin the value of the `Access-Control-Allow-Origin` response header,\ninstead of specifying the `*` wildcard. The value of the header\n`Access-Control-Allow-Origin` is same as the `Origin` header provided by\nthe client.\n\nSupport: Extended",
+                  "items": {
+                    "description": "The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and\nencoding rules specified in RFC3986.  The CORSOrigin MUST include both a\nscheme (\"http\" or \"https\") and a scheme-specific-part, or it should be a single '*' character.\nURIs that include an authority MUST include a fully qualified domain name or\nIP address as the host.",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "(^\\*$)|(^(http(s)?):\\/\\/(((\\*\\.)?([a-zA-Z0-9\\-]+\\.)*[a-zA-Z0-9-]+|\\*)(:([0-9]{1,5}))?)$)",
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "AllowOrigins cannot contain '*' alongside other origins",
+                      "rule": "!('*' in self && self.size() > 1)"
+                    }
+                  ]
+                },
+                "exposeHeaders": {
+                  "description": "ExposeHeaders indicates which HTTP response headers can be exposed\nto client-side scripts in response to a cross-origin request.\n\nA CORS-safelisted response header is an HTTP header in a CORS response\nthat it is considered safe to expose to the client scripts.\nThe CORS-safelisted response headers include the following headers:\n`Cache-Control`\n`Content-Language`\n`Content-Length`\n`Content-Type`\n`Expires`\n`Last-Modified`\n`Pragma`\n(See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)\nThe CORS-safelisted response headers are exposed to client by default.\n\nWhen an HTTP header name is specified using the `ExposeHeaders` field,\nthis additional header will be exposed as part of the response to the\nclient.\n\nHeader names are not case-sensitive.\n\nMultiple header names in the value of the `Access-Control-Expose-Headers`\nresponse header are separated by a comma (\",\").\n\nA wildcard indicates that the responses with all HTTP headers are exposed\nto clients. The `Access-Control-Expose-Headers` response header can only\nuse `*` wildcard as value when the request is not credentialed.\n\nWhen the `exposeHeaders` config field contains the \"*\" wildcard and\nthe request is credentialed, the gateway cannot use the `*` wildcard in\nthe `Access-Control-Expose-Headers` response header.\n\nSupport: Extended",
+                  "items": {
+                    "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                    "type": "string"
+                  },
+                  "maxItems": 64,
+                  "type": "array",
+                  "x-kubernetes-list-type": "set"
+                },
+                "maxAge": {
+                  "default": 5,
+                  "description": "MaxAge indicates the duration (in seconds) for the client to cache the\nresults of a \"preflight\" request.\n\nThe information provided by the `Access-Control-Allow-Methods` and\n`Access-Control-Allow-Headers` response headers can be cached by the\nclient until the time specified by `Access-Control-Max-Age` elapses.\n\nThe default value of `Access-Control-Max-Age` response header is 5\n(seconds).\n\nWhen the `MaxAge` field is unspecified, the gateway sets the response\nheader \"Access-Control-Max-Age: 5\" by default.",
+                  "format": "int32",
+                  "minimum": 1,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "csrf": {
+              "description": "csrf specifies the Cross-Site Request Forgery (CSRF) policy for this traffic policy.\n\nThe CSRF policy has the following behavior:\n* Safe methods (`GET`, `HEAD`, `OPTIONS`) are automatically allowed.\n* Requests without `Sec-Fetch-Site` or `Origin` headers are assumed to\n  be same-origin or non-browser requests and are allowed.\n* Otherwise, the `Sec-Fetch-Site` header is checked, with a fallback to\n  comparing the `Origin` header to the `Host` header.",
+              "properties": {
+                "additionalOrigins": {
+                  "description": "`additionalOrigins` specifies additional source origins that will be\nallowed in addition to the destination origin. The `Origin` consists of\na scheme and a host, with an optional port, and takes the form\n`<scheme>://<host>(:<port>)`.",
+                  "items": {
+                    "maxLength": 256,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "directResponse": {
+              "description": "`directResponse` configures the policy to send a direct response to the\nclient.",
+              "properties": {
+                "body": {
+                  "description": "Body defines the content to be returned in the HTTP response body.\nThe maximum length of the body is restricted to prevent excessively large responses.\nIf this field is omitted, no body is included in the response.",
+                  "maxLength": 4096,
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "conditional": {
+                  "description": "`conditional`, if set, will enable conditional policy execution. You must either set this, or set the top level directResponse fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "`condition` must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "`policy` definition.",
+                        "properties": {
+                          "body": {
+                            "description": "Body defines the content to be returned in the HTTP response body.\nThe maximum length of the body is restricted to prevent excessively large responses.\nIf this field is omitted, no body is included in the response.",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "status": {
+                            "description": "StatusCode defines the HTTP status code to return for this route.",
+                            "format": "int32",
+                            "maximum": 599,
+                            "minimum": 200,
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "status is required",
+                            "rule": "has(self.status)"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                },
+                "status": {
+                  "description": "StatusCode defines the HTTP status code to return for this route.",
+                  "format": "int32",
+                  "maximum": 599,
+                  "minimum": 200,
+                  "type": "integer"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.body),has(self.status)].filter(x,x==true).size() == 0 : true"
+                },
+                {
+                  "message": "status: Required value",
+                  "rule": "has(self.conditional) ? true : has(self.status)"
+                }
+              ]
+            },
+            "extAuth": {
+              "description": "extAuth specifies the external authentication configuration for the policy.\nThis controls what external server to send requests to for authentication.\n\nAn extAuth policy can be conditionally set by nesting configuration under the `conditional` field.",
+              "properties": {
+                "backendRef": {
+                  "description": "`backendRef` references the External Authorization server to reach.\n\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ]
+                },
+                "conditional": {
+                  "description": "`conditional`, if set, will enable conditional policy execution. You must either set this, or set the top level extAuth fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "`condition` must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "`policy` definition.",
+                        "properties": {
+                          "backendRef": {
+                            "description": "`backendRef` references the External Authorization server to reach.\n\nSupported types: `Service` and `Backend`.",
+                            "properties": {
+                              "group": {
+                                "default": "",
+                                "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                "maxLength": 253,
+                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "default": "Service",
+                                "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the referent.",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                "format": "int32",
+                                "maximum": 65535,
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "Must have port for Service reference",
+                                "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                              }
+                            ]
+                          },
+                          "failureMode": {
+                            "description": "FailureMode controls behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
+                            "enum": [
+                              "FailOpen",
+                              "FailClosed"
+                            ],
+                            "type": "string"
+                          },
+                          "forwardBody": {
+                            "description": "`forwardBody` configures whether to include the HTTP body in the request.\nIf enabled, the request body will be buffered.",
+                            "properties": {
+                              "maxSize": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "description": "`maxSize` specifies, in bytes, the largest body that will be buffered\nand sent to the authorization server. If the body size is larger than\n`maxSize`, then the request will be rejected with a response.",
+                                "maxLength": 32,
+                                "minLength": 1,
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true,
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "value must be at least 1 byte and fit within uint32",
+                                    "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "maxSize"
+                            ],
+                            "type": "object"
+                          },
+                          "grpc": {
+                            "description": "grpc specifies that the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
+                            "properties": {
+                              "contextExtensions": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "description": "`contextExtensions` specifies additional arbitrary key-value pairs to\nsend to the authorization server in the `context_extensions` field.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              },
+                              "requestMetadata": {
+                                "additionalProperties": {
+                                  "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "`requestMetadata` specifies metadata to be sent to the authorization\nserver. This maps to the `metadata_context.filter_metadata` field of the\nrequest, and allows dynamic CEL expressions. If unset, by default the\n`envoy.filters.http.jwt_authn` key is set if the JWT policy is used as\nwell, for compatibility.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "http": {
+                            "description": "`http` specifies that the HTTP protocol should be used for connecting to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
+                            "properties": {
+                              "addRequestHeaders": {
+                                "additionalProperties": {
+                                  "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "`addRequestHeaders` specifies what additional headers to add to the\nrequest to the authorization server. While `allowedRequestHeaders` just\npasses the original headers through, `addRequestHeaders` allows defining\ncustom headers based on CEL expressions.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              },
+                              "allowedRequestHeaders": {
+                                "description": "`allowedRequestHeaders` specifies what additional headers from the client request\nwill be sent to the authorization server.\n\nIf unset, the following headers are sent by default: `Authorization`.",
+                                "items": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "maxItems": 64,
+                                "type": "array"
+                              },
+                              "allowedResponseHeaders": {
+                                "description": "`allowedResponseHeaders` specifies what headers from the authorization response\nwill be copied into the request to the backend.",
+                                "items": {
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "maxItems": 64,
+                                "type": "array"
+                              },
+                              "path": {
+                                "description": "`path` specifies the path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "redirect": {
+                                "description": "`redirect` defines an optional expression to determine a path to\nredirect to on authorization failure. This is useful to redirect to a\nsign-in page.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "responseMetadata": {
+                                "additionalProperties": {
+                                  "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "`responseMetadata` specifies what metadata fields should be constructed\nfrom the authorization response. These will be included under the\n`extauthz` variable in future CEL expressions. Setting this is useful\nfor things like logging usernames, without needing to include them as\nheaders to the backend, as `allowedResponseHeaders` would.",
+                                "maxProperties": 64,
+                                "type": "object"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "backendRef is required",
+                            "rule": "has(self.backendRef)"
+                          },
+                          {
+                            "message": "exactly one of the fields in [grpc http] must be set",
+                            "rule": "[has(self.grpc),has(self.http)].filter(x,x==true).size() == 1"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                },
+                "failureMode": {
+                  "description": "FailureMode controls behavior when the external authorization service is\nunavailable or returns an error. \"FailOpen\" allows the request to continue.\n\"FailClosed\" (default) denies the request.",
+                  "enum": [
+                    "FailOpen",
+                    "FailClosed"
+                  ],
+                  "type": "string"
+                },
+                "forwardBody": {
+                  "description": "`forwardBody` configures whether to include the HTTP body in the request.\nIf enabled, the request body will be buffered.",
+                  "properties": {
+                    "maxSize": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "`maxSize` specifies, in bytes, the largest body that will be buffered\nand sent to the authorization server. If the body size is larger than\n`maxSize`, then the request will be rejected with a response.",
+                      "maxLength": 32,
+                      "minLength": 1,
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true,
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "value must be at least 1 byte and fit within uint32",
+                          "rule": "(self >= 1 && self <= 4294967295) || self.size() > 0"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "maxSize"
+                  ],
+                  "type": "object"
+                },
+                "grpc": {
+                  "description": "grpc specifies that the gRPC External Authorization\n[protocol](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto) should be used.",
+                  "properties": {
+                    "contextExtensions": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "`contextExtensions` specifies additional arbitrary key-value pairs to\nsend to the authorization server in the `context_extensions` field.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "requestMetadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`requestMetadata` specifies metadata to be sent to the authorization\nserver. This maps to the `metadata_context.filter_metadata` field of the\nrequest, and allows dynamic CEL expressions. If unset, by default the\n`envoy.filters.http.jwt_authn` key is set if the JWT policy is used as\nwell, for compatibility.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "http": {
+                  "description": "`http` specifies that the HTTP protocol should be used for connecting to\nthe authorization server. The authorization server must return a `200`\nstatus code, otherwise the request is considered an authorization\nfailure.",
+                  "properties": {
+                    "addRequestHeaders": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`addRequestHeaders` specifies what additional headers to add to the\nrequest to the authorization server. While `allowedRequestHeaders` just\npasses the original headers through, `addRequestHeaders` allows defining\ncustom headers based on CEL expressions.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    },
+                    "allowedRequestHeaders": {
+                      "description": "`allowedRequestHeaders` specifies what additional headers from the client request\nwill be sent to the authorization server.\n\nIf unset, the following headers are sent by default: `Authorization`.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "allowedResponseHeaders": {
+                      "description": "`allowedResponseHeaders` specifies what headers from the authorization response\nwill be copied into the request to the backend.",
+                      "items": {
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "maxItems": 64,
+                      "type": "array"
+                    },
+                    "path": {
+                      "description": "`path` specifies the path to send to the authorization server. If\nunset, this defaults to the original request path.\nThis is a CEL expression, which allows customizing the path based on the\nincoming request. For example, to add a prefix, use\n`\"/prefix/\" + request.path`.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "redirect": {
+                      "description": "`redirect` defines an optional expression to determine a path to\nredirect to on authorization failure. This is useful to redirect to a\nsign-in page.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "responseMetadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`responseMetadata` specifies what metadata fields should be constructed\nfrom the authorization response. These will be included under the\n`extauthz` variable in future CEL expressions. Setting this is useful\nfor things like logging usernames, without needing to include them as\nheaders to the backend, as `allowedResponseHeaders` would.",
+                      "maxProperties": 64,
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "exactly one of the fields in [grpc http] must be set",
+                  "rule": "has(self.conditional) || [has(self.grpc),has(self.http)].filter(x,x==true).size() == 1"
+                },
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.backendRef),has(self.failureMode),has(self.forwardBody),has(self.grpc),has(self.http)].filter(x,x==true).size() == 0 : true"
+                },
+                {
+                  "message": "backendRef: Required value",
+                  "rule": "has(self.conditional) ? true : has(self.backendRef)"
+                }
+              ]
+            },
+            "extProc": {
+              "description": "extProc specifies the external processing configuration for the policy.",
+              "properties": {
+                "backendRef": {
+                  "description": "`backendRef` references the External Processor server to reach.\nSupported types: `Service` and `Backend`.",
+                  "properties": {
+                    "group": {
+                      "default": "",
+                      "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                      "maxLength": 253,
+                      "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "default": "Service",
+                      "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name is the name of the referent.",
+                      "maxLength": 253,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                      "maxLength": 63,
+                      "minLength": 1,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                      "format": "int32",
+                      "maximum": 65535,
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ],
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "Must have port for Service reference",
+                      "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                    }
+                  ]
+                },
+                "conditional": {
+                  "description": "`conditional`, if set, will enable conditional policy execution. You must either set this, or set the top level extProc fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "`condition` must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "`policy` definition.",
+                        "properties": {
+                          "backendRef": {
+                            "description": "`backendRef` references the External Processor server to reach.\nSupported types: `Service` and `Backend`.",
+                            "properties": {
+                              "group": {
+                                "default": "",
+                                "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                "maxLength": 253,
+                                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                "type": "string"
+                              },
+                              "kind": {
+                                "default": "Service",
+                                "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name is the name of the referent.",
+                                "maxLength": 253,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                "maxLength": 63,
+                                "minLength": 1,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                "format": "int32",
+                                "maximum": 65535,
+                                "minimum": 1,
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "name"
+                            ],
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "Must have port for Service reference",
+                                "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "backendRef is required",
+                            "rule": "has(self.backendRef)"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.backendRef)].filter(x,x==true).size() == 0 : true"
+                },
+                {
+                  "message": "backendRef: Required value",
+                  "rule": "has(self.conditional) ? true : has(self.backendRef)"
+                }
+              ]
+            },
+            "headerModifiers": {
+              "description": "headerModifiers defines the policy to modify request and response headers.",
+              "properties": {
+                "request": {
+                  "description": "Request modifies request headers.",
+                  "properties": {
+                    "add": {
+                      "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "remove": {
+                      "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that the header\nnames are case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object"
+                },
+                "response": {
+                  "description": "Response modifies response headers.",
+                  "properties": {
+                    "add": {
+                      "description": "Add adds the given header(s) (name, value) to the request\nbefore the action. It appends to any existing values associated\nwith the header name.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  add:\n  - name: \"my-header\"\n    value: \"bar,baz\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: foo,bar,baz",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "remove": {
+                      "description": "Remove the given header(s) from the HTTP request before the action. The\nvalue of Remove is a list of HTTP header names. Note that the header\nnames are case-insensitive (see\nhttps://datatracker.ietf.org/doc/html/rfc2616#section-4.2).\n\nInput:\n  GET /foo HTTP/1.1\n  my-header1: foo\n  my-header2: bar\n  my-header3: baz\n\nConfig:\n  remove: [\"my-header1\", \"my-header3\"]\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header2: bar",
+                      "items": {
+                        "type": "string"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "Set overwrites the request with the given header (name, value)\nbefore the action.\n\nInput:\n  GET /foo HTTP/1.1\n  my-header: foo\n\nConfig:\n  set:\n  - name: \"my-header\"\n    value: \"bar\"\n\nOutput:\n  GET /foo HTTP/1.1\n  my-header: bar",
+                      "items": {
+                        "description": "HTTPHeader represents an HTTP Header name and value as defined by RFC 7230.",
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the HTTP Header to be matched. Name matching MUST be\ncase-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).\n\nIf multiple entries specify equivalent header names, the first entry with\nan equivalent name MUST be considered for a match. Subsequent entries\nwith an equivalent header name MUST be ignored. Due to the\ncase-insensitivity of header names, \"foo\" and \"Foo\" are considered\nequivalent.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value is the value of HTTP Header to be matched.\n<gateway:experimental:description>\nMust consist of printable US-ASCII characters, optionally separated\nby single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2\n</gateway:experimental:description>\n\n<gateway:experimental:validation:Pattern=`^[!-~]+([\\t ]?[!-~]+)*$`>",
+                            "maxLength": 4096,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [request response] must be set",
+                  "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                }
+              ]
+            },
+            "hostRewrite": {
+              "description": "`hostRewrite` specifies how to rewrite the `Host` header for requests.\n\nIf the `HTTPRoute` `urlRewrite` filter already specifies a host rewrite,\nthis setting is ignored.",
+              "properties": {
+                "mode": {
+                  "description": "`mode` sets the hostname rewrite mode.\n\nThe following may be specified:\n* `Auto`: automatically set the `Host` header based on the destination.\n* `None`: do not rewrite the `Host` header. The original `Host` header\n  will be passed through.\n\nThis setting defaults to `Auto` when connecting to hostname-based\n`Backend` types, and `None` otherwise, for `Service` or IP-based\nbackends.",
+                  "enum": [
+                    "Auto",
+                    "None"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "mode"
+              ],
+              "type": "object"
+            },
+            "jwtAuthentication": {
+              "description": "`jwtAuthentication` authenticates users based on JWT tokens.",
+              "properties": {
+                "location": {
+                  "description": "`location` controls where JWT credentials are read from.\nIf omitted, credentials are read from the `Authorization` header with the `Bearer ` prefix.",
+                  "properties": {
+                    "cookie": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "header": {
+                      "properties": {
+                        "name": {
+                          "description": "HTTPHeaderName is the name of an HTTP header.\n\nValid values include:\n\n* \"Authorization\"\n* \"Set-Cookie\"\n\nInvalid values include:\n\n  - \":method\" - \":\" is an invalid character. This means that HTTP/2 pseudo\n    headers are not currently supported by this type.\n  - \"/invalid\" - \"/ \" is an invalid character",
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "pattern": "^[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                          "type": "string"
+                        },
+                        "prefix": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    },
+                    "queryParameter": {
+                      "properties": {
+                        "name": {
+                          "maxLength": 256,
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "exactly one of the fields in [header queryParameter cookie] must be set",
+                      "rule": "[has(self.header),has(self.queryParameter),has(self.cookie)].filter(x,x==true).size() == 1"
+                    }
+                  ]
+                },
+                "mcp": {
+                  "description": "`mcp` optionally enables MCP OAuth metadata endpoint handling\nand MCP-specific authentication behavior on top of standard JWT validation.\nWhen set, the gateway will serve the MCP OAuth metadata discovery endpoints.",
+                  "properties": {
+                    "provider": {
+                      "description": "`provider` specifies the identity provider to use for MCP authentication flows.",
+                      "enum": [
+                        "Auth0",
+                        "Keycloak"
+                      ],
+                      "type": "string"
+                    },
+                    "resourceMetadata": {
+                      "additionalProperties": {
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "description": "`resourceMetadata` defines the metadata to use for MCP resources,\nserved at the MCP OAuth metadata endpoints.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "mode": {
+                  "default": "Strict",
+                  "description": "`mode` is the validation mode for JWT authentication.",
+                  "enum": [
+                    "Strict",
+                    "Optional",
+                    "Permissive"
+                  ],
+                  "type": "string"
+                },
+                "providers": {
+                  "items": {
+                    "properties": {
+                      "audiences": {
+                        "description": "`audiences` specifies the list of allowed audiences that are allowed\naccess. This corresponds to the `aud` claim\n([RFC 7519 §4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)).\nIf unset, any audience is allowed.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "maxItems": 64,
+                        "minItems": 1,
+                        "type": "array"
+                      },
+                      "issuer": {
+                        "description": "`issuer` identifies the IdP that issued the JWT. This corresponds to the\n`iss` claim ([RFC 7519 §4.1.1](https://tools.ietf.org/html/rfc7519#section-4.1.1)).",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "jwks": {
+                        "description": "`jwks` defines the JSON Web Key Set used to validate the signature of the\nJWT.",
+                        "properties": {
+                          "inline": {
+                            "description": "`inline` specifies an inline JSON Web Key Set used to validate the\nsignature of the JWT.",
+                            "maxLength": 65536,
+                            "minLength": 2,
+                            "type": "string"
+                          },
+                          "remote": {
+                            "description": "`remote` specifies how to reach the JSON Web Key Set from a remote\naddress.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "`backendRef` references the remote JWKS server to reach.\nSupported types are `Service` and static `Backend`. An\n`AgentgatewayPolicy` containing backend TLS config can then be attached\nto the `Service` or `Backend` in order to set TLS options for a\nconnection to the remote `jwks` source.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ]
+                              },
+                              "cacheDuration": {
+                                "default": "5m",
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "invalid duration value",
+                                    "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                                  },
+                                  {
+                                    "message": "cacheDuration must be at least 5m.",
+                                    "rule": "duration(self) >= duration('5m')"
+                                  }
+                                ]
+                              },
+                              "jwksPath": {
+                                "description": "Path to the IdP `jwks` endpoint, relative to the root, commonly\n`\".well-known/jwks.json\"`.",
+                                "maxLength": 2000,
+                                "minLength": 1,
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "backendRef",
+                              "jwksPath"
+                            ],
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "exactly one of the fields in [remote inline] must be set",
+                            "rule": "[has(self.remote),has(self.inline)].filter(x,x==true).size() == 1"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "issuer",
+                      "jwks"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 64,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "required": [
+                "providers"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "jwtAuthentication.mcp requires exactly one provider",
+                  "rule": "!has(self.mcp) || size(self.providers) == 1"
+                },
+                {
+                  "message": "jwtAuthentication.mcp requires mode Strict",
+                  "rule": "!has(self.mcp) || !has(self.mode) || self.mode == 'Strict'"
+                }
+              ]
+            },
+            "phase": {
+              "description": "The phase to apply the traffic policy to. If the phase is `PreRouting`,\nthe `targetRef` must be a `Gateway` or a `Listener`. `PreRouting` is\ntypically used only when a policy needs to influence the routing\ndecision.\n\nEven when using `PostRouting` mode, the policy can target the\n`Gateway` or `Listener`. This is a helper for applying the policy to all\nroutes under that `Gateway` or `Listener`, and follows the merging logic\ndescribed above.\n\nNote: `PreRouting` and `PostRouting` rules do not merge together. These\nare independent execution phases. That is, all `PreRouting` rules will\nmerge and execute, then all `PostRouting` rules will merge and execute.\n\nIf unset, this defaults to `PostRouting`.",
+              "enum": [
+                "PreRouting",
+                "PostRouting"
+              ],
+              "type": "string"
+            },
+            "rateLimit": {
+              "description": "rateLimit specifies the rate limiting configuration for the policy.\nThis controls the rate at which requests are allowed to be processed.",
+              "properties": {
+                "conditional": {
+                  "description": "`conditional`, if set, will enable conditional policy execution. You must either set this, or set the top level rateLimit fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "`condition` must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "`policy` definition.",
+                        "properties": {
+                          "global": {
+                            "description": "Global defines a global rate limiting policy using an external service.",
+                            "properties": {
+                              "backendRef": {
+                                "description": "`backendRef` references the rate limit server to reach.\nSupported types: `Service` and `Backend`.",
+                                "properties": {
+                                  "group": {
+                                    "default": "",
+                                    "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                                    "maxLength": 253,
+                                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "default": "Service",
+                                    "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of the referent.",
+                                    "maxLength": 253,
+                                    "minLength": 1,
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                                    "maxLength": 63,
+                                    "minLength": 1,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                                    "format": "int32",
+                                    "maximum": 65535,
+                                    "minimum": 1,
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "name"
+                                ],
+                                "type": "object",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "Must have port for Service reference",
+                                    "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                                  }
+                                ]
+                              },
+                              "descriptors": {
+                                "description": "`descriptors` define the dimensions for rate limiting. These values are\npassed to the rate limit service which applies configured limits based\non them. Each descriptor represents a single rate limit rule with one or\nmore entries.",
+                                "items": {
+                                  "properties": {
+                                    "cost": {
+                                      "description": "`cost` is a Common Expression Language (`CEL`) expression that determines\nthe cost of the request for this descriptor. If unset, `Requests` costs\ndefault to 1, and `Tokens` costs default to the total token count.\n\n`Tokens` cost are evaluated after the request has completed. For non-streaming requests, `request`, `llm`, and\n`response` fields are all available; for streaming requests, `response` is not available (however, all LLM\nattributes are in `llm`). For `Requests`, cost is computed during the request phase.\n\nSee https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "entries": {
+                                      "description": "`entries` are the individual components that make up this descriptor.",
+                                      "items": {
+                                        "description": "A descriptor entry defines a single entry in a rate limit descriptor.",
+                                        "properties": {
+                                          "expression": {
+                                            "description": "`expression` is a Common Expression Language (`CEL`) expression that\ndefines the value for the descriptor.\n\nFor example, to rate limit based on the Client IP: `source.address`.\n\nSee https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.",
+                                            "maxLength": 16384,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "`name` specifies the name of the descriptor.",
+                                            "maxLength": 64,
+                                            "minLength": 1,
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "expression",
+                                          "name"
+                                        ],
+                                        "type": "object"
+                                      },
+                                      "maxItems": 16,
+                                      "minItems": 1,
+                                      "type": "array"
+                                    },
+                                    "unit": {
+                                      "description": "`unit` defines what to use as the cost function. If unspecified,\n`Requests` is used.",
+                                      "enum": [
+                                        "Requests",
+                                        "Tokens"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "entries"
+                                  ],
+                                  "type": "object"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array"
+                              },
+                              "domain": {
+                                "description": "`domain` specifies the domain under which this limit should apply.\nThis is an arbitrary string that enables a rate limit server to distinguish between different applications.",
+                                "maxLength": 256,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "failureMode": {
+                                "description": "`failureMode` controls behavior when the remote rate limit service is\nunavailable or returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) denies the request.",
+                                "enum": [
+                                  "FailOpen",
+                                  "FailClosed"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "backendRef",
+                              "descriptors",
+                              "domain"
+                            ],
+                            "type": "object"
+                          },
+                          "local": {
+                            "description": "Local defines a local rate limiting policy.",
+                            "items": {
+                              "description": "Policy for local rate limiting. Local rate limits are handled locally on a per-proxy basis, without co-ordination\nbetween instances of the proxy.",
+                              "properties": {
+                                "burst": {
+                                  "description": "`burst` specifies an allowance of requests above the request-per-unit\nthat should be allowed within a short period of time.",
+                                  "format": "int32",
+                                  "type": "integer"
+                                },
+                                "requests": {
+                                  "description": "`requests` specifies the number of HTTP requests per unit of time that\nare allowed. Requests exceeding this limit will fail with a `429`\nerror.",
+                                  "format": "int32",
+                                  "minimum": 1,
+                                  "type": "integer"
+                                },
+                                "tokens": {
+                                  "description": "`tokens` specifies the number of LLM tokens per unit of time that are\nallowed. Requests exceeding this limit will fail with a `429` error.\n\nBoth input and output tokens are counted. However, token counts are not known until the request completes. As a\nresult, token-based rate limits will apply to future requests only.",
+                                  "format": "int32",
+                                  "minimum": 1,
+                                  "type": "integer"
+                                },
+                                "unit": {
+                                  "description": "`unit` specifies the unit of time that requests are limited on.",
+                                  "enum": [
+                                    "Seconds",
+                                    "Minutes",
+                                    "Hours"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "unit"
+                              ],
+                              "type": "object",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "exactly one of the fields in [requests tokens] must be set",
+                                  "rule": "[has(self.requests),has(self.tokens)].filter(x,x==true).size() == 1"
+                                }
+                              ]
+                            },
+                            "maxItems": 16,
+                            "minItems": 1,
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "at least one of the fields in [global local] must be set",
+                            "rule": "[has(self.global),has(self.local)].filter(x,x==true).size() >= 1"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                },
+                "global": {
+                  "description": "Global defines a global rate limiting policy using an external service.",
+                  "properties": {
+                    "backendRef": {
+                      "description": "`backendRef` references the rate limit server to reach.\nSupported types: `Service` and `Backend`.",
+                      "properties": {
+                        "group": {
+                          "default": "",
+                          "description": "Group is the group of the referent. For example, \"gateway.networking.k8s.io\".\nWhen unspecified or empty string, core API group is inferred.",
+                          "maxLength": 253,
+                          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                          "type": "string"
+                        },
+                        "kind": {
+                          "default": "Service",
+                          "description": "Kind is the Kubernetes resource kind of the referent. For example\n\"Service\".\n\nDefaults to \"Service\" when not specified.\n\nExternalName services can refer to CNAME DNS records that may live\noutside of the cluster and as such are difficult to reason about in\nterms of conformance. They also may not be safe to forward to (see\nCVE-2021-25740 for more information). Implementations SHOULD NOT\nsupport ExternalName Services.\n\nSupport: Core (Services with a type other than ExternalName)\n\nSupport: Implementation-specific (Services with type ExternalName)",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name is the name of the referent.",
+                          "maxLength": 253,
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace is the namespace of the backend. When unspecified, the local\nnamespace is inferred.\n\nNote that when a namespace different than the local namespace is specified,\na ReferenceGrant object is required in the referent namespace to allow that\nnamespace's owner to accept the reference. See the ReferenceGrant\ndocumentation for details.\n\nSupport: Core",
+                          "maxLength": 63,
+                          "minLength": 1,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                          "type": "string"
+                        },
+                        "port": {
+                          "description": "Port specifies the destination port number to use for this resource.\nPort is required when the referent is a Kubernetes Service. In this\ncase, the port number is the service port number, not the target port.\nFor other resources, destination port might be derived from the referent\nresource or this field.",
+                          "format": "int32",
+                          "maximum": 65535,
+                          "minimum": 1,
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "name"
+                      ],
+                      "type": "object",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Must have port for Service reference",
+                          "rule": "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) : true"
+                        }
+                      ]
+                    },
+                    "descriptors": {
+                      "description": "`descriptors` define the dimensions for rate limiting. These values are\npassed to the rate limit service which applies configured limits based\non them. Each descriptor represents a single rate limit rule with one or\nmore entries.",
+                      "items": {
+                        "properties": {
+                          "cost": {
+                            "description": "`cost` is a Common Expression Language (`CEL`) expression that determines\nthe cost of the request for this descriptor. If unset, `Requests` costs\ndefault to 1, and `Tokens` costs default to the total token count.\n\n`Tokens` cost are evaluated after the request has completed. For non-streaming requests, `request`, `llm`, and\n`response` fields are all available; for streaming requests, `response` is not available (however, all LLM\nattributes are in `llm`). For `Requests`, cost is computed during the request phase.\n\nSee https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "entries": {
+                            "description": "`entries` are the individual components that make up this descriptor.",
+                            "items": {
+                              "description": "A descriptor entry defines a single entry in a rate limit descriptor.",
+                              "properties": {
+                                "expression": {
+                                  "description": "`expression` is a Common Expression Language (`CEL`) expression that\ndefines the value for the descriptor.\n\nFor example, to rate limit based on the Client IP: `source.address`.\n\nSee https://agentgateway.dev/docs/standalone/latest/reference/cel/ for more info.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "`name` specifies the name of the descriptor.",
+                                  "maxLength": 64,
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "expression",
+                                "name"
+                              ],
+                              "type": "object"
+                            },
+                            "maxItems": 16,
+                            "minItems": 1,
+                            "type": "array"
+                          },
+                          "unit": {
+                            "description": "`unit` defines what to use as the cost function. If unspecified,\n`Requests` is used.",
+                            "enum": [
+                              "Requests",
+                              "Tokens"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "entries"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array"
+                    },
+                    "domain": {
+                      "description": "`domain` specifies the domain under which this limit should apply.\nThis is an arbitrary string that enables a rate limit server to distinguish between different applications.",
+                      "maxLength": 256,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "failureMode": {
+                      "description": "`failureMode` controls behavior when the remote rate limit service is\nunavailable or returns an error. `FailOpen` allows the request to continue.\n`FailClosed` (default) denies the request.",
+                      "enum": [
+                        "FailOpen",
+                        "FailClosed"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "backendRef",
+                    "descriptors",
+                    "domain"
+                  ],
+                  "type": "object"
+                },
+                "local": {
+                  "description": "Local defines a local rate limiting policy.",
+                  "items": {
+                    "description": "Policy for local rate limiting. Local rate limits are handled locally on a per-proxy basis, without co-ordination\nbetween instances of the proxy.",
+                    "properties": {
+                      "burst": {
+                        "description": "`burst` specifies an allowance of requests above the request-per-unit\nthat should be allowed within a short period of time.",
+                        "format": "int32",
+                        "type": "integer"
+                      },
+                      "requests": {
+                        "description": "`requests` specifies the number of HTTP requests per unit of time that\nare allowed. Requests exceeding this limit will fail with a `429`\nerror.",
+                        "format": "int32",
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "tokens": {
+                        "description": "`tokens` specifies the number of LLM tokens per unit of time that are\nallowed. Requests exceeding this limit will fail with a `429` error.\n\nBoth input and output tokens are counted. However, token counts are not known until the request completes. As a\nresult, token-based rate limits will apply to future requests only.",
+                        "format": "int32",
+                        "minimum": 1,
+                        "type": "integer"
+                      },
+                      "unit": {
+                        "description": "`unit` specifies the unit of time that requests are limited on.",
+                        "enum": [
+                          "Seconds",
+                          "Minutes",
+                          "Hours"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "unit"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "exactly one of the fields in [requests tokens] must be set",
+                        "rule": "[has(self.requests),has(self.tokens)].filter(x,x==true).size() == 1"
+                      }
+                    ]
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [conditional global local] must be set",
+                  "rule": "[has(self.conditional),has(self.global),has(self.local)].filter(x,x==true).size() >= 1"
+                },
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.global),has(self.local)].filter(x,x==true).size() == 0 : true"
+                }
+              ]
+            },
+            "retry": {
+              "description": "retry defines the policy for retrying requests.",
+              "properties": {
+                "attempts": {
+                  "description": "Attempts specifies the maximum number of times an individual request\nfrom the gateway to a backend should be retried.\n\nIf the maximum number of retries has been attempted without a successful\nresponse from the backend, the Gateway MUST return an error.\n\nWhen this field is unspecified, the number of times to attempt to retry\na backend request is implementation-specific.\n\nSupport: Extended",
+                  "type": "integer"
+                },
+                "backoff": {
+                  "description": "Backoff specifies the minimum duration a Gateway should wait between\nretry attempts and is represented in Gateway API Duration formatting.\n\nFor example, setting the `rules[].retry.backoff` field to the value\n`100ms` will cause a backend request to first be retried approximately\n100 milliseconds after timing out or receiving a response code configured\nto be retriable.\n\nAn implementation MAY use an exponential or alternative backoff strategy\nfor subsequent retry attempts, MAY cap the maximum backoff duration to\nsome amount greater than the specified minimum, and MAY add arbitrary\njitter to stagger requests, as long as unsuccessful backend requests are\nnot retried before the configured minimum duration.\n\nIf a Request timeout (`rules[].timeouts.request`) is configured on the\nroute, the entire duration of the initial request and any retry attempts\nMUST not exceed the Request timeout duration. If any retry attempts are\nstill in progress when the Request timeout duration has been reached,\nthese SHOULD be canceled if possible and the Gateway MUST immediately\nreturn a timeout error.\n\nIf a BackendRequest timeout (`rules[].timeouts.backendRequest`) is\nconfigured on the route, any retry attempts which reach the configured\nBackendRequest timeout duration without a response SHOULD be canceled if\npossible and the Gateway should wait for at least the specified backoff\nduration before attempting to retry the backend request again.\n\nIf a BackendRequest timeout is _not_ configured on the route, retry\nattempts MAY time out after an implementation default duration, or MAY\nremain pending until a configured Request timeout or implementation\ndefault duration for total request time is reached.\n\nWhen this field is unspecified, the time to wait between retry attempts\nis implementation-specific.\n\nSupport: Extended",
+                  "pattern": "^([0-9]{1,5}(h|m|s|ms)){1,4}$",
+                  "type": "string"
+                },
+                "codes": {
+                  "description": "Codes defines the HTTP response status codes for which a backend request\nshould be retried.\n\nSupport: Extended",
+                  "items": {
+                    "description": "HTTPRouteRetryStatusCode defines an HTTP response status code for\nwhich a backend request should be retried.\n\nImplementations MUST support the following status codes as retriable:\n\n* 500\n* 502\n* 503\n* 504\n\nImplementations MAY support specifying additional discrete values in the\n500-599 range.\n\nImplementations MAY support specifying discrete values in the 400-499 range,\nwhich are often inadvisable to retry.\n\n<gateway:experimental>",
+                    "maximum": 599,
+                    "minimum": 400,
+                    "type": "integer"
+                  },
+                  "type": "array",
+                  "x-kubernetes-list-type": "atomic"
+                }
+              },
+              "type": "object"
+            },
+            "timeouts": {
+              "description": "`timeouts` defines the timeouts for requests.\nIt is applicable to `HTTPRoute` resources and ignored for other targeted\nkinds.",
+              "properties": {
+                "request": {
+                  "description": "request specifies a timeout for an individual request from the gateway to a backend. This covers the time from when\nthe request first starts being sent from the gateway to when the full response has been received from the backend.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid duration value",
+                      "rule": "matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')"
+                    },
+                    {
+                      "message": "request must be at least 1ms",
+                      "rule": "duration(self) >= duration('100ms')"
+                    }
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "transformation": {
+              "description": "transformation is used to mutate and transform requests and responses\nbefore forwarding them to the destination.",
+              "properties": {
+                "conditional": {
+                  "description": "`conditional`, if set, will enable conditional policy execution. You must either set this, or set the top level transformation fields.\nThe first matching policy will be executed.\nA single policy may be provided without a condition set; if so, it must be the last policy and will be the fallback\nin case no conditions are met.",
+                  "items": {
+                    "properties": {
+                      "condition": {
+                        "description": "`condition` must evaluate to true for this policy to execute.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "policy": {
+                        "description": "`policy` definition.",
+                        "properties": {
+                          "request": {
+                            "description": "`request` is used to modify the request path.",
+                            "properties": {
+                              "add": {
+                                "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "description": "The name of the header to add.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                          "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "body": {
+                                "description": "`body` controls manipulation of the HTTP body.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "additionalProperties": {
+                                  "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                                "maxProperties": 16,
+                                "minProperties": 1,
+                                "type": "object"
+                              },
+                              "remove": {
+                                "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                                "items": {
+                                  "description": "An HTTP Header Name.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                      "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                    }
+                                  ]
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "set": {
+                                "description": "`set` is a list of headers and the value they should be set to.",
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "description": "The name of the header to add.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                          "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [add body metadata remove set] must be set",
+                                "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                              }
+                            ]
+                          },
+                          "response": {
+                            "description": "`response` is used to modify the response path.",
+                            "properties": {
+                              "add": {
+                                "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "description": "The name of the header to add.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                          "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "body": {
+                                "description": "`body` controls manipulation of the HTTP body.",
+                                "maxLength": 16384,
+                                "minLength": 1,
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "additionalProperties": {
+                                  "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                                  "maxLength": 16384,
+                                  "minLength": 1,
+                                  "type": "string"
+                                },
+                                "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                                "maxProperties": 16,
+                                "minProperties": 1,
+                                "type": "object"
+                              },
+                              "remove": {
+                                "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                                "items": {
+                                  "description": "An HTTP Header Name.",
+                                  "maxLength": 256,
+                                  "minLength": 1,
+                                  "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                      "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                    }
+                                  ]
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-type": "set"
+                              },
+                              "set": {
+                                "description": "`set` is a list of headers and the value they should be set to.",
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "description": "The name of the header to add.",
+                                      "maxLength": 256,
+                                      "minLength": 1,
+                                      "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                          "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                                        }
+                                      ]
+                                    },
+                                    "value": {
+                                      "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                                      "maxLength": 16384,
+                                      "minLength": 1,
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                "maxItems": 16,
+                                "minItems": 1,
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              }
+                            },
+                            "type": "object",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "at least one of the fields in [add body metadata remove set] must be set",
+                                "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "at least one of the fields in [request response] must be set",
+                            "rule": "[has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "policy"
+                    ],
+                    "type": "object"
+                  },
+                  "maxItems": 16,
+                  "minItems": 1,
+                  "type": "array",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "conditional entries without condition must be last",
+                      "rule": "self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e, !has(e.condition)) || !has(self[size(self) - 1].condition))"
+                    }
+                  ]
+                },
+                "request": {
+                  "description": "`request` is used to modify the request path.",
+                  "properties": {
+                    "add": {
+                      "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "`body` controls manipulation of the HTTP body.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "An HTTP Header Name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "`set` is a list of headers and the value they should be set to.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                },
+                "response": {
+                  "description": "`response` is used to modify the response path.",
+                  "properties": {
+                    "add": {
+                      "description": "`add` is a list of headers to add to the request and what that value\nshould be set to. If there is already a header with these values then\nappend the value as an extra entry.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "body": {
+                      "description": "`body` controls manipulation of the HTTP body.",
+                      "maxLength": 16384,
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "additionalProperties": {
+                        "description": "CELExpression represents a Common Expression Language (CEL) expression.",
+                        "maxLength": 16384,
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "description": "`metadata` stores CEL-evaluated values under the `metadata` CEL variable\nfor subsequent policy evaluations. `metadata` is evaluated before header\nor body transformations.",
+                      "maxProperties": 16,
+                      "minProperties": 1,
+                      "type": "object"
+                    },
+                    "remove": {
+                      "description": "`remove` is a list of header names to remove from the request or\nresponse.",
+                      "items": {
+                        "description": "An HTTP Header Name.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                            "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                          }
+                        ]
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-type": "set"
+                    },
+                    "set": {
+                      "description": "`set` is a list of headers and the value they should be set to.",
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "description": "The name of the header to add.",
+                            "maxLength": 256,
+                            "minLength": 1,
+                            "pattern": "^:?[A-Za-z0-9!#$%&'*+\\-.^_\\x60|~]+$",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "pseudo-headers must be one of :authority, :method, :path, :scheme, or :status",
+                                "rule": "!self.startsWith(':') || self in [':authority', ':method', ':path', ':scheme', ':status']"
+                              }
+                            ]
+                          },
+                          "value": {
+                            "description": "`value` is the CEL expression to apply to generate the output value for\nthe header.",
+                            "maxLength": 16384,
+                            "minLength": 1,
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "maxItems": 16,
+                      "minItems": 1,
+                      "type": "array",
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "at least one of the fields in [add body metadata remove set] must be set",
+                      "rule": "[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size() >= 1"
+                    }
+                  ]
+                }
+              },
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of the fields in [conditional request response] must be set",
+                  "rule": "[has(self.conditional),has(self.request),has(self.response)].filter(x,x==true).size() >= 1"
+                },
+                {
+                  "message": "conditional cannot be set with any other field",
+                  "rule": "has(self.conditional) ? [has(self.request),has(self.response)].filter(x,x==true).size() == 0 : true"
+                }
+              ]
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "phase PreRouting only supports extAuth, transformation, extProc, jwtAuthentication, basicAuthentication, and apiKeyAuthentication",
+              "rule": "has(self.phase) && self.phase == 'PreRouting' ? [has(self.authorization),has(self.cors),has(self.csrf),has(self.directResponse),has(self.headerModifiers),has(self.hostRewrite),has(self.rateLimit),has(self.retry),has(self.timeouts)].filter(x,x==true).size() == 0 : true"
+            }
+          ]
+        }
+      },
+      "type": "object",
+      "x-kubernetes-validations": [
+        {
+          "message": "At least one of traffic, frontend, or backend must be provided.",
+          "rule": "has(self.traffic) || has(self.frontend) || has(self.backend)"
+        },
+        {
+          "message": "backend.mcp may not be used with a Service target",
+          "rule": "!has(self.backend) || !has(self.backend.mcp) || ((!has(self.targetRefs) || !self.targetRefs.exists(t, t.kind == 'Service')) && (!has(self.targetSelectors) || !self.targetSelectors.exists(t, t.kind == 'Service')))"
+        },
+        {
+          "message": "backend.mcp may not target an AgentgatewayBackend sectionName",
+          "rule": "!has(self.backend) || !has(self.backend.mcp) || ((!has(self.targetRefs) || !self.targetRefs.exists(t, t.kind == 'AgentgatewayBackend' && has(t.sectionName))) && (!has(self.targetSelectors) || !self.targetSelectors.exists(t, t.kind == 'AgentgatewayBackend' && has(t.sectionName))))"
+        },
+        {
+          "message": "backend.ai may not be used with a Service target",
+          "rule": "!has(self.backend) || !has(self.backend.ai) || ((!has(self.targetRefs) || !self.targetRefs.exists(t, t.kind == 'Service')) && (!has(self.targetSelectors) || !self.targetSelectors.exists(t, t.kind == 'Service')))"
+        },
+        {
+          "message": "traffic.jwtAuthentication may not be used with backend.mcp.authentication in the same policy",
+          "rule": "!(has(self.traffic) && has(self.traffic.jwtAuthentication) && has(self.backend) && has(self.backend.mcp) && has(self.backend.mcp.authentication))"
+        },
+        {
+          "message": "the 'frontend' field can only target a Gateway",
+          "rule": "has(self.frontend) && has(self.targetRefs) ? self.targetRefs.all(t, t.kind == 'Gateway' && !has(t.sectionName)) : true"
+        },
+        {
+          "message": "the 'frontend' field can only target a Gateway",
+          "rule": "has(self.frontend) && has(self.targetSelectors) ? self.targetSelectors.all(t, t.kind == 'Gateway' && !has(t.sectionName)) : true"
+        },
+        {
+          "message": "the 'traffic' field can only target a Gateway, ListenerSet, GRPCRoute, HTTPRoute, or InferencePool",
+          "rule": "has(self.traffic) && has(self.targetRefs) ? self.targetRefs.all(t, t.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'ListenerSet', 'InferencePool']) : true"
+        },
+        {
+          "message": "the 'traffic' field can only target a Gateway, ListenerSet, GRPCRoute, HTTPRoute, or InferencePool",
+          "rule": "has(self.traffic) && has(self.targetSelectors) ? self.targetSelectors.all(t, t.kind in ['Gateway', 'HTTPRoute', 'GRPCRoute', 'ListenerSet', 'InferencePool']) : true"
+        },
+        {
+          "message": "the 'traffic.phase=PreRouting' field can only target a Gateway or ListenerSet",
+          "rule": "has(self.targetRefs) && has(self.traffic) && has(self.traffic.phase) && self.traffic.phase == 'PreRouting' ? self.targetRefs.all(t, t.kind in ['Gateway', 'ListenerSet']) : true"
+        },
+        {
+          "message": "the 'traffic.phase=PreRouting' field can only target a Gateway or ListenerSet",
+          "rule": "has(self.targetSelectors) && has(self.traffic) && has(self.traffic.phase) && self.traffic.phase == 'PreRouting' ? self.targetSelectors.all(t, t.kind in ['Gateway', 'ListenerSet']) : true"
+        },
+        {
+          "message": "exactly one of the fields in [targetRefs targetSelectors] must be set",
+          "rule": "[has(self.targetRefs),has(self.targetSelectors)].filter(x,x==true).size() == 1"
+        }
+      ]
+    },
+    "status": {
+      "description": "status defines the current state of AgentgatewayPolicy.",
+      "properties": {
+        "ancestors": {
+          "description": "Ancestors is a list of ancestor resources (usually Gateways) that are\nassociated with the policy, and the status of the policy with respect to\neach ancestor. When this policy attaches to a parent, the controller that\nmanages the parent and the ancestors MUST add an entry to this list when\nthe controller first sees the policy and SHOULD update the entry as\nappropriate when the relevant ancestor is modified.\n\nNote that choosing the relevant ancestor is left to the Policy designers;\nan important part of Policy design is designing the right object level at\nwhich to namespace this status.\n\nNote also that implementations MUST ONLY populate ancestor status for\nthe Ancestor resources they are responsible for. Implementations MUST\nuse the ControllerName field to uniquely identify the entries in this list\nthat they are responsible for.\n\nNote that to achieve this, the list of PolicyAncestorStatus structs\nMUST be treated as a map with a composite key, made up of the AncestorRef\nand ControllerName fields combined.\n\nA maximum of 16 ancestors will be represented in this list. An empty list\nmeans the Policy is not relevant for any ancestors.\n\nIf this slice is full, implementations MUST NOT add further entries.\nInstead they MUST consider the policy unimplementable and signal that\non any related resources such as the ancestor that would be referenced\nhere. For example, if this list was full on BackendTLSPolicy, no\nadditional Gateways would be able to reference the Service targeted by\nthe BackendTLSPolicy.",
+          "items": {
+            "description": "PolicyAncestorStatus describes the status of a route with respect to an\nassociated Ancestor.\n\nAncestors refer to objects that are either the Target of a policy or above it\nin terms of object hierarchy. For example, if a policy targets a Service, the\nPolicy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and\nthe GatewayClass. Almost always, in this hierarchy, the Gateway will be the most\nuseful object to place Policy status on, so we recommend that implementations\nSHOULD use Gateway as the PolicyAncestorStatus object unless the designers\nhave a _very_ good reason otherwise.\n\nIn the context of policy attachment, the Ancestor is used to distinguish which\nresource results in a distinct application of this policy. For example, if a policy\ntargets a Service, it may have a distinct result per attached Gateway.\n\nPolicies targeting the same resource may have different effects depending on the\nancestors of those resources. For example, different Gateways targeting the same\nService may have different capabilities, especially if they have different underlying\nimplementations.\n\nFor example, in BackendTLSPolicy, the Policy attaches to a Service that is\nused as a backend in a HTTPRoute that is itself attached to a Gateway.\nIn this case, the relevant object for status is the Gateway, and that is the\nancestor object referred to in this status.\n\nNote that a parent is also an ancestor, so for objects where the parent is the\nrelevant object for status, this struct SHOULD still be used.\n\nThis struct is intended to be used in a slice that's effectively a map,\nwith a composite key made up of the AncestorRef and the ControllerName.",
+            "properties": {
+              "ancestorRef": {
+                "description": "AncestorRef corresponds with a ParentRef in the spec that this\nPolicyAncestorStatus struct describes the status of.",
+                "properties": {
+                  "group": {
+                    "default": "gateway.networking.k8s.io",
+                    "description": "Group is the group of the referent.\nWhen unspecified, \"gateway.networking.k8s.io\" is inferred.\nTo set the core API group (such as for a \"Service\" kind referent),\nGroup must be explicitly set to \"\" (empty string).\n\nSupport: Core",
+                    "maxLength": 253,
+                    "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "default": "Gateway",
+                    "description": "Kind is kind of the referent.\n\nThere are two kinds of parent resources with \"Core\" support:\n\n* Gateway (Gateway conformance profile)\n* Service (Mesh conformance profile, ClusterIP Services only)\n\nSupport for other resources is Implementation-Specific.",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name is the name of the referent.\n\nSupport: Core",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace is the namespace of the referent. When unspecified, this refers\nto the local namespace of the Route.\n\nNote that there are specific rules for ParentRefs which cross namespace\nboundaries. Cross-namespace references are only valid if they are explicitly\nallowed by something in the namespace they are referring to. For example:\nGateway has the AllowedRoutes field, and ReferenceGrant provides a\ngeneric way to enable any other kind of cross-namespace reference.\n\n<gateway:experimental:description>\nParentRefs from a Route to a Service in the same namespace are \"producer\"\nroutes, which apply default routing rules to inbound connections from\nany namespace to the Service.\n\nParentRefs from a Route to a Service in a different namespace are\n\"consumer\" routes, and these routing rules are only applied to outbound\nconnections originating from the same namespace as the Route, for which\nthe intended destination of the connections are a Service targeted as a\nParentRef of the Route.\n</gateway:experimental:description>\n\nSupport: Core",
+                    "maxLength": 63,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+                    "type": "string"
+                  },
+                  "port": {
+                    "description": "Port is the network port this Route targets. It can be interpreted\ndifferently based on the type of parent resource.\n\nWhen the parent resource is a Gateway, this targets all listeners\nlistening on the specified port that also support this kind of Route(and\nselect this Route). It's not recommended to set `Port` unless the\nnetworking behaviors specified in a Route must apply to a specific port\nas opposed to a listener(s) whose port(s) may be changed. When both Port\nand SectionName are specified, the name and port of the selected listener\nmust match both specified values.\n\n<gateway:experimental:description>\nWhen the parent resource is a Service, this targets a specific port in the\nService spec. When both Port (experimental) and SectionName are specified,\nthe name and port of the selected port must match both specified values.\n</gateway:experimental:description>\n\nImplementations MAY choose to support other parent resources.\nImplementations supporting other types of parent resources MUST clearly\ndocument how/if Port is interpreted.\n\nFor the purpose of status, an attachment is considered successful as\nlong as the parent resource accepts it partially. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment\nfrom the referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route,\nthe Route MUST be considered detached from the Gateway.\n\nSupport: Extended",
+                    "format": "int32",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
+                  "sectionName": {
+                    "description": "SectionName is the name of a section within the target resource. In the\nfollowing resources, SectionName is interpreted as the following:\n\n* Gateway: Listener name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n* Service: Port name. When both Port (experimental) and SectionName\nare specified, the name and port of the selected listener must match\nboth specified values.\n\nImplementations MAY choose to support attaching Routes to other resources.\nIf that is the case, they MUST clearly document how SectionName is\ninterpreted.\n\nWhen unspecified (empty string), this will reference the entire resource.\nFor the purpose of status, an attachment is considered successful if at\nleast one section in the parent resource accepts it. For example, Gateway\nlisteners can restrict which Routes can attach to them by Route kind,\nnamespace, or hostname. If 1 of 2 Gateway listeners accept attachment from\nthe referencing Route, the Route MUST be considered successfully\nattached. If no Gateway listeners accept attachment from this Route, the\nRoute MUST be considered detached from the Gateway.\n\nSupport: Core",
+                    "maxLength": 253,
+                    "minLength": 1,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              },
+              "conditions": {
+                "description": "Conditions describes the status of the Policy with respect to the given Ancestor.\n\n<gateway:util:excludeFromCRD>\n\nNotes for implementors:\n\nConditions are a listType `map`, which means that they function like a\nmap with a key of the `type` field _in the k8s apiserver_.\n\nThis means that implementations must obey some rules when updating this\nsection.\n\n* Implementations MUST perform a read-modify-write cycle on this field\n  before modifying it. That is, when modifying this field, implementations\n  must be confident they have fetched the most recent version of this field,\n  and ensure that changes they make are on that recent version.\n* Implementations MUST NOT remove or reorder Conditions that they are not\n  directly responsible for. For example, if an implementation sees a Condition\n  with type `special.io/SomeField`, it MUST NOT remove, change or update that\n  Condition.\n* Implementations MUST always _merge_ changes into Conditions of the same Type,\n  rather than creating more than one Condition of the same Type.\n* Implementations MUST always update the `observedGeneration` field of the\n  Condition to the `metadata.generation` of the Gateway at the time of update creation.\n* If the `observedGeneration` of a Condition is _greater than_ the value the\n  implementation knows about, then it MUST NOT perform the update on that Condition,\n  but must wait for a future reconciliation and status update. (The assumption is that\n  the implementation's copy of the object is stale and an update will be re-triggered\n  if relevant.)\n\n</gateway:util:excludeFromCRD>",
+                "items": {
+                  "description": "Condition contains details for one aspect of the current state of this API Resource.",
+                  "properties": {
+                    "lastTransitionTime": {
+                      "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                      "format": "date-time",
+                      "type": "string"
+                    },
+                    "message": {
+                      "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                      "maxLength": 32768,
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "reason": {
+                      "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                      "maxLength": 1024,
+                      "minLength": 1,
+                      "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                      "type": "string"
+                    },
+                    "status": {
+                      "description": "status of the condition, one of True, False, Unknown.",
+                      "enum": [
+                        "True",
+                        "False",
+                        "Unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                      "maxLength": 316,
+                      "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "lastTransitionTime",
+                    "message",
+                    "reason",
+                    "status",
+                    "type"
+                  ],
+                  "type": "object"
+                },
+                "maxItems": 8,
+                "minItems": 1,
+                "type": "array",
+                "x-kubernetes-list-map-keys": [
+                  "type"
+                ],
+                "x-kubernetes-list-type": "map"
+              },
+              "controllerName": {
+                "description": "ControllerName is a domain/path string that indicates the name of the\ncontroller that wrote this status. This corresponds with the\ncontrollerName field on GatewayClass.\n\nExample: \"example.net/gateway-controller\".\n\nThe format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are\nvalid Kubernetes names\n(https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).\n\nControllers MUST populate this field when writing status. Controllers should ensure that\nentries to status populated with their ControllerName are cleaned up when they are no\nlonger necessary.",
+                "maxLength": 253,
+                "minLength": 1,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\\/[A-Za-z0-9\\/\\-._~%!$&'()*+,;=:]+$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "ancestorRef",
+              "conditions",
+              "controllerName"
+            ],
+            "type": "object"
+          },
+          "maxItems": 16,
+          "type": "array",
+          "x-kubernetes-list-type": "atomic"
+        }
+      },
+      "required": [
+        "ancestors"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
## Summary

- Add `crds/agent-gateway.sh` config script targeting Agent Gateway v1.2.1
- Generate three `v1alpha1` JSON schemas under the `agentgateway.dev` group: `AgentgatewayBackend`, `AgentgatewayParameters`, and `AgentgatewayPolicy`
- Update schema catalog with the new entries

Closes: #321